### PR TITLE
Fixed typographical error, changed appart to apart in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,6 @@ is essentially just a pair.
 Reading and Writing Ipe files
 -----------------------------
 
-Appart from geometric types, HGeometry provides some interface for reading and
+Apart from geometric types, HGeometry provides some interface for reading and
 writing Ipe (http://ipe7.sourceforge.net). However, this is all very work in
 progress. Hence, the API is experimental and may change at any time!


### PR DESCRIPTION
@noinia, I've corrected a typographical error in the documentation of the [hgeometry](https://github.com/noinia/hgeometry) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.