### PR TITLE
onSegment always returns true for zero-length segments

### DIFF
--- a/hgeometry.cabal
+++ b/hgeometry.cabal
@@ -428,6 +428,7 @@ test-suite hspec
                  Data.OrdSeqSpec
                  Data.Geometry.Ipe.ReaderSpec
                  Data.Geometry.PolygonSpec
+                 Data.Geometry.LineSegmentSpec
                  Data.Geometry.PointSpec
                  Data.Geometry.Polygon.Convex.ConvexSpec
                  Data.Geometry.KDTreeSpec

--- a/src/Data/Geometry/LineSegment.hs
+++ b/src/Data/Geometry/LineSegment.hs
@@ -217,7 +217,10 @@ onSegment       :: (Ord r, Fractional r, Arity d)
 p `onSegment` l = let s          = l^.start.core
                       t          = l^.end.core
                       inRange' x = 0 <= x && x <= 1
-                  in maybe False inRange' $ scalarMultiple (p .-. s) (t .-. s)
+                  in
+                  if s == t -- zero length segment
+                  then p == s
+                  else maybe False inRange' $ scalarMultiple (p .-. s) (t .-. s)
 
 
 -- | The left and right end point (or left below right if they have equal x-coords)

--- a/test/Data/Geometry/LineSegmentSpec.hs
+++ b/test/Data/Geometry/LineSegmentSpec.hs
@@ -1,0 +1,24 @@
+{-# LANGUAGE ScopedTypeVariables #-}
+module Data.Geometry.LineSegmentSpec where
+
+import           Data.Ext
+import qualified Data.Foldable                      as F
+import           Data.Geometry
+import           Data.Geometry.Box
+import           Data.Geometry.LineSegment
+import           Data.Geometry.Point
+import qualified Data.Seq                           as Seq
+import qualified Data.Set                           as Set
+import           GHC.TypeLits
+import           Test.Hspec
+import           Test.QuickCheck
+import           Test.QuickCheck.HGeometryInstances ()
+
+spec :: Spec
+spec =
+  describe "onSegment" $
+    it "handles zero length segments correctly" $ do
+        let zeroSegment :: LineSegment 2 () Double
+            zeroSegment = ClosedLineSegment (Point2 0.0 0.0 :+ ()) (Point2 0.0 0.0 :+ ())
+        (Point2 0 0 `onSegment` zeroSegment) `shouldBe` True
+        (Point2 1 0 `onSegment` zeroSegment) `shouldBe` False


### PR DESCRIPTION
Simple fix, also added regression test this. Found this while doing check by `inPolygon` on polygons of structure `A B C D A` (last point equals first).