### PR TITLE
Increase base lower bound since this package requires GHC >=8.2

### DIFF
--- a/hgeometry.cabal
+++ b/hgeometry.cabal
@@ -203,7 +203,7 @@ library
 
   -- other-extensions:
   build-depends:
-                  base             >= 4.9       &&     < 5
+                  base             >= 4.10      &&     < 5
                 , bifunctors       >= 4.1
                 , bytestring       >= 0.10
                 , containers       >= 0.5.5


### PR DESCRIPTION
Alternatively we could add some CPP to allow building on 8.0 as well, if that interests you.
As a hackage trustee, I have made a metadata revision to hgeometry 0.7.0.0 adding this bound.