### PR TITLE
Make tests work with QuickCheck ^>= 2.13.

### DIFF
--- a/hgeometry-combinatorial/test/Data/PlanarGraphSpec.hs
+++ b/hgeometry-combinatorial/test/Data/PlanarGraphSpec.hs
@@ -109,7 +109,7 @@ fromAdjacencyListsOld adjM = planarGraph' . toCycleRep n $ perm
     toDart                    :: (VertexId s Primal,VertexId s Primal)
                               -> STR' s [Dart s]
                               -> STR' s [Dart s]
-    toDart (u,v) (STR m a ds) = let dir = if u < v then PlanarGraph.Positive else Negative
+    toDart (u,v) (STR m a ds) = let dir = if u < v then PlanarGraph.Positive else PlanarGraph.Negative
                                     t'  = (min u v, max u v)
                                in case SM.lookup t' m of
       Just a' -> STR m                  a     (Dart (Arc a') dir : ds)


### PR DESCRIPTION
QuickCheck 2.13 introduced a Negative newtype modifier, which
introduces a name conflict with the `PlanarGraph.Negative` constructor.

Because the .Positive invocation in this line is prefixed, I chose to
make .Negative prefixed too, which frees us from having to add an
upper bound for QuickCheck in the .cabal file.