### PR TITLE
Use GitHub Actions to supplement Travis CI.

### DIFF
--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ghc: ['8.6', '8.8', '8.10']
+        ghc: ['8.6', '8.8']
         os: [ubuntu-latest, macOS-latest]
         # exclude:
         #   # 8.8.3 on windows throws segfaults when installing deps

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ghc: ['8.2', '8.4', '8.6', '8.8']
+        ghc: ['8.4', '8.6', '8.8']
         os: [ubuntu-latest, macOS-latest]
         # exclude:
         #   # 8.8.3 on windows throws segfaults when installing deps

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -40,11 +40,11 @@ jobs:
     - name: Install dependencies
       run: |
         cabal v2-update || cabal v2-update
-        cabal v2-build --only-dependencies --enable-tests --enable-benchmarks all
+        cabal v2-build --only-dependencies --enable-tests --enable-benchmarks hgeometry-test
     - name: Build
       run: cabal v2-build hgeometry-test
     - name: Test
       run: |
         cabal v2-test --test-show-details=always hgeometry-test
-    # - name: Check documentation syntax
-    #   run: cabal v2-haddock all
+    - name: Check documentation syntax
+      run: cabal v2-haddock hgeometry-test

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         ghc: ['8.6', '8.8', '8.10']
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        os: [ubuntu-latest, macOS-latest]
         # exclude:
         #   # 8.8.3 on windows throws segfaults when installing deps
         #   - os: windows-latest

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -13,10 +13,6 @@ jobs:
       matrix:
         ghc: ['8.4', '8.6', '8.8']
         os: [ubuntu-latest, macOS-latest]
-        # exclude:
-        #   # 8.8.3 on windows throws segfaults when installing deps
-        #   - os: windows-latest
-        #     ghc: '8.8'
     name: GHC ${{ matrix.ghc }} / ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        ghc: ['8.6', '8.8']
+        ghc: ['8.2', '8.4', '8.6', '8.8']
         os: [ubuntu-latest, macOS-latest]
         # exclude:
         #   # 8.8.3 on windows throws segfaults when installing deps

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -1,0 +1,50 @@
+name: Cabal build/test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        ghc: ['8.6', '8.8', '8.10']
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+        # exclude:
+        #   # 8.8.3 on windows throws segfaults when installing deps
+        #   - os: windows-latest
+        #     ghc: '8.8'
+    name: GHC ${{ matrix.ghc }} / ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-haskell@v1
+      with:
+        ghc-version: ${{ matrix.ghc }}
+        cabal-version: 'latest'
+
+    - name: Cache
+      uses: actions/cache@v1
+      env:
+        cache-name: cache-cabal
+      with:
+        path: ~/.cabal
+        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.ghc }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
+        restore-keys: |
+          ${{ runner.os }}-build-${{ env.cache-name }}-
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
+
+    - name: Install dependencies
+      run: |
+        cabal v2-update || cabal v2-update
+        cabal v2-build --only-dependencies --enable-tests --enable-benchmarks all
+    - name: Build
+      run: cabal v2-build hgeometry-test
+    - name: Test
+      run: |
+        cabal v2-test --test-show-details=always hgeometry-test
+    # - name: Check documentation syntax
+    #   run: cabal v2-haddock all

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -46,5 +46,5 @@ jobs:
     - name: Test
       run: |
         cabal v2-test --test-show-details=always hgeometry-test
-    - name: Check documentation syntax
-      run: cabal v2-haddock hgeometry-test
+    # - name: Check documentation syntax
+    #   run: cabal v2-haddock hgeometry-test


### PR DESCRIPTION
Feel free to squash this PR. The commit history is messy and not important.

Also, there are build failures with both ghc 8.2 and ghc 8.10.