### PR TITLE
Fix warnings in hgeometry.

### DIFF
--- a/hgeometry/src/Algorithms/Geometry/ConvexHull/GrahamScan.hs
+++ b/hgeometry/src/Algorithms/Geometry/ConvexHull/GrahamScan.hs
@@ -126,6 +126,9 @@ hull' (a:b:ps) = NonEmpty.fromList $ hull'' [b,a] ps
       | rightTurn (x^.core) (y^.core) (z^.core) = h
       | otherwise                               = cleanMiddle (z:x:rest)
     cleanMiddle _                               = error "cleanMiddle: too few points"
+hull' _ = error
+  "Algorithms.Geometry.ConvexHull.GrahamScan.hull' requires a list with at least \
+  \two elements."
 
 rightTurn       :: (Ord r, Num r) => Point 2 r -> Point 2 r -> Point 2 r -> Bool
 rightTurn a b c = ccw a b c == CW

--- a/hgeometry/src/Algorithms/Geometry/ConvexHull/Naive.hs
+++ b/hgeometry/src/Algorithms/Geometry/ConvexHull/Naive.hs
@@ -14,9 +14,7 @@ import           Data.Geometry.Point
 import           Data.Geometry.Triangle
 import           Data.Geometry.Vector
 import           Data.Intersection(intersects)
-import qualified Data.List as List
 import           Data.List.NonEmpty (NonEmpty(..))
-import qualified Data.List.NonEmpty as NonEmpty
 import           Data.Maybe (listToMaybe, isNothing)
 import           Data.Util
 --------------------------------------------------------------------------------
@@ -50,15 +48,14 @@ lowerHullAll (toList -> pts) = let mkT (Three p q r) = Triangle p q r in
 
 
 
-killOverlapping :: (Ord r, Fractional r) => [Triangle 3 p r] -> [Triangle 3 p r]
-killOverlapping = foldr keepIfNotOverlaps []
+_killOverlapping :: (Ord r, Fractional r) => [Triangle 3 p r] -> [Triangle 3 p r]
+_killOverlapping = foldr keepIfNotOverlaps []
   where
     keepIfNotOverlaps t ts | any (t `overlaps`) ts = ts
                            | otherwise             = t:ts
 
-
-t1@(Triangle p q r) `overlaps` t2@(Triangle a b c) = upperHalfSpaceOf t1 == upperHalfSpaceOf t2
-                                                  && False
+overlaps :: (Fractional r, Ord r) => Triangle 3 p1 r -> Triangle 3 p2 r -> Bool
+t1 `overlaps` t2 = upperHalfSpaceOf t1 == upperHalfSpaceOf t2 && False
 
 
 

--- a/hgeometry/src/Algorithms/Geometry/ConvexHull/QuickHull.hs
+++ b/hgeometry/src/Algorithms/Geometry/ConvexHull/QuickHull.hs
@@ -1,6 +1,6 @@
 module Algorithms.Geometry.ConvexHull.QuickHull( convexHull ) where
 
-import           Control.Lens ((^.),(&),(.~))
+import           Control.Lens ((^.))
 import           Data.Ext
 import qualified Data.Foldable as F
 import           Data.Geometry.Line

--- a/hgeometry/src/Algorithms/Geometry/LinearProgramming/LP2DRIC.hs
+++ b/hgeometry/src/Algorithms/Geometry/LinearProgramming/LP2DRIC.hs
@@ -42,8 +42,8 @@ import           System.Random.Shuffle
 --------------------------------------------------------------------------------
 
 -- | Solve a linear program
-solveLinearProgram :: MonadRandom m => LinearProgram 2 r -> m (LPSolution 2 r)
-solveLinearProgram = undefined
+_solveLinearProgram :: MonadRandom m => LinearProgram 2 r -> m (LPSolution 2 r)
+_solveLinearProgram = undefined
 
 
 -- | Solves a bounded linear program in 2d. Returns Nothing if there is no
@@ -219,7 +219,9 @@ initialize (LinearProgram c (m1:m2:hs)) = (LPState c [m1,m2] p, hs)
   where
     Just p = asA @(Point 2 r)
            $ (m1^.boundingPlane._asLine) `intersect` (m2^.boundingPlane._asLine)
-
+initialize _ = error
+  "Algorithms.Geometry.LinearProgramming.LP2DRIC.initialize requires \
+  \at least two constraints."
 
 
 --------------------------------------------------------------------------------
@@ -234,13 +236,13 @@ initialize (LinearProgram c (m1:m2:hs)) = (LPState c [m1,m2] p, hs)
 -- - \(c \cdot d > 0\), and
 -- - \(d \cdot n(h) \geq 0\), wherefor every half space \(h\).
 --
-findD                      :: (Ord r, Fractional r)
+_findD                      :: (Ord r, Fractional r)
                            => LinearProgram 2 r -> Maybe (Vector 2 r)
-findD (LinearProgram c hs) = do hls <- collectOn nl hs'
-                                d   <- toVec <$> oneDLinearProgramming v nl hls
-                                       -- the direction v here does not really matter
-                                if c `dot` d > 0 then pure d
-                                                 else Nothing
+_findD (LinearProgram c hs) = do hls <- collectOn nl hs'
+                                 d   <- toVec <$> oneDLinearProgramming v nl hls
+                                        -- the direction v here does not really matter
+                                 if c `dot` d > 0 then pure d
+                                                  else Nothing
   where
     -- we interpret the points on nl as directions w.r.t the origin
     nl@(Line _ v) = perpendicularTo (Line (origin .+^ c) c)
@@ -248,14 +250,14 @@ findD (LinearProgram c hs) = do hls <- collectOn nl hs'
 
     -- every halfspace creates an allowed set of directions, modelled by a
     -- half-line on nl
-    toHL h = let n              = h^.boundingPlane.normalVec
+    toHL h = let _n              = h^.boundingPlane.normalVec
              in undefined
 
 
 -- | Either finds an unbounded Haflline, or evidence the two halfspaces that provide
 -- evidence that no solution exists
-findUnBoundedHalfLine :: LinearProgram 2 r -> Either (Two (HalfSpace 2 r)) (HalfLine 2 r)
-findUnBoundedHalfLine = undefined -- use findD then find the starting point
+_findUnBoundedHalfLine :: LinearProgram 2 r -> Either (Two (HalfSpace 2 r)) (HalfLine 2 r)
+_findUnBoundedHalfLine = undefined -- use findD then find the starting point
 
 
 

--- a/hgeometry/src/Algorithms/Geometry/SmallestEnclosingBall/RIC.hs
+++ b/hgeometry/src/Algorithms/Geometry/SmallestEnclosingBall/RIC.hs
@@ -31,8 +31,8 @@ import           Data.Maybe (fromMaybe, mapMaybe, catMaybes)
 import           Data.Ord (comparing)
 import           System.Random.Shuffle (shuffle)
 
-import Data.RealNumber.Rational
-import Debug.Trace
+-- import Data.RealNumber.Rational
+-- import Debug.Trace
 
 --------------------------------------------------------------------------------
 

--- a/hgeometry/src/Algorithms/Geometry/SoS.hs
+++ b/hgeometry/src/Algorithms/Geometry/SoS.hs
@@ -22,12 +22,6 @@ module Algorithms.Geometry.SoS
 import Algorithms.Geometry.SoS.Orientation
 import Algorithms.Geometry.SoS.Determinant
 import Algorithms.Geometry.SoS.Sign
-import Control.CanAquire
-import Control.Lens
-import Data.Ext
-import Data.Geometry.Point.Internal
-import Data.Geometry.Properties
-import Data.Geometry.Vector
 
 --------------------------------------------------------------------------------
 

--- a/hgeometry/src/Algorithms/Geometry/SoS/AsPoint.hs
+++ b/hgeometry/src/Algorithms/Geometry/SoS/AsPoint.hs
@@ -1,9 +1,7 @@
 module Algorithms.Geometry.SoS.AsPoint where
 
 import           Control.CanAquire
-import           Control.Lens
 import           Data.Ext
-import           Data.Geometry.Point.Class
 import           Data.Geometry.Point.Internal
 import           Data.Geometry.Properties
 import           Data.Geometry.Vector

--- a/hgeometry/src/Algorithms/Geometry/SoS/Expr.hs
+++ b/hgeometry/src/Algorithms/Geometry/SoS/Expr.hs
@@ -3,7 +3,6 @@ module Algorithms.Geometry.SoS.Expr where
 
 import           Control.Lens
 import qualified Data.List as List
-import           Data.List.NonEmpty (NonEmpty(..),nonEmpty)
 
 --------------------------------------------------------------------------------
 
@@ -36,6 +35,8 @@ hasVariables = foldExpr (const False)
 
 instance (Num r) => Num (Expr i r) where
   fromInteger = Constant . fromInteger
+  abs _ = error "'abs' not defined for Algorithms.Geometry.SoS.Expr.Expr"
+  signum _ = error "'signum' not defined for Algorithms.Geometry.SoS.Expr.Expr"
   negate      = \case
     Negate e -> e
     e        -> Negate e

--- a/hgeometry/src/Algorithms/Geometry/SoS/Symbolic.hs
+++ b/hgeometry/src/Algorithms/Geometry/SoS/Symbolic.hs
@@ -21,8 +21,7 @@ import qualified Data.List as List
 import qualified Data.Map as Map
 import qualified Data.Map.Merge.Strict as Map
 import           Data.Maybe (isNothing)
-import           Data.Word
-import           Test.QuickCheck (Arbitrary(..), listOf, suchThat)
+import           Test.QuickCheck (Arbitrary(..), listOf)
 import           Test.QuickCheck.Instances ()
 
 --------------------------------------------------------------------------------

--- a/hgeometry/src/Algorithms/Geometry/WellSeparatedPairDecomposition/WSPD.hs
+++ b/hgeometry/src/Algorithms/Geometry/WellSeparatedPairDecomposition/WSPD.hs
@@ -25,7 +25,7 @@ import           Data.Geometry.Vector
 import qualified Data.Geometry.Vector as GV
 import qualified Data.IntMap.Strict as IntMap
 import qualified Data.LSeq as LSeq
-import           Data.LSeq (LSeq,toSeq,ViewL(..),ViewR(..),pattern (:<|))
+import           Data.LSeq (LSeq, toSeq,pattern (:<|))
 import qualified Data.List as L
 import qualified Data.List.NonEmpty as NonEmpty
 import           Data.Maybe
@@ -37,7 +37,7 @@ import qualified Data.Vector as V
 import qualified Data.Vector.Mutable as MV
 import           GHC.TypeLits
 
-import           Debug.Trace
+-- import           Debug.Trace
 
 --------------------------------------------------------------------------------
 
@@ -177,6 +177,7 @@ distributePoints' k levels pts
     level p = maybe (k-1) _unLevel $ levels V.! (p^.extra.core)
     append v i p = MV.read v i >>= MV.write v i . (S.|> p)
 
+fromSeqUnsafe :: S.Seq a -> LSeq n a
 fromSeqUnsafe = LSeq.promise . LSeq.fromSeq
 
 -- | Given a sequence of points, whose index is increasing in the first
@@ -266,9 +267,11 @@ compactEnds' (l0 :<| s0) = fmap fromSeqUnsafe . goL $ l0 S.<| toSeq s0
     goL s@(S.viewl -> l S.:< s') = hasLevel l >>= \case
                                      False -> goR s
                                      True  -> goL s'
+    goL _ = error "Unreachable, but cannot prove it in Haskell"
     goR s@(S.viewr -> s' S.:> r) = hasLevel r >>= \case
                                      False -> pure s
                                      True  -> goR s'
+    goR _ = error "Unreachable, but cannot prove it in Haskell"
 
 
 -- | Given the points, ordered by their j^th coordinate, split the point set

--- a/hgeometry/src/Data/Geometry/IntervalTree.hs
+++ b/hgeometry/src/Data/Geometry/IntervalTree.hs
@@ -56,6 +56,7 @@ fromIntervals    :: (Ord r, IntervalLike i, NumType i ~ r)
 fromIntervals is = foldr insert (createTree pts) is
   where
     endPoints (asRange -> Range' a b) = [a,b]
+    endPoints _ = error "Unreachable, but cannot prove it in Haskell"
     pts = List.sort . concatMap endPoints $ is
 
 -- | Lists the intervals. We don't guarantee anything about the order

--- a/hgeometry/src/Data/Geometry/PlanarSubdivision.hs
+++ b/hgeometry/src/Data/Geometry/PlanarSubdivision.hs
@@ -122,13 +122,13 @@ fromPolygon p (MultiPolygon vs hs) iD oD = case NonEmpty.nonEmpty hs of
 
 data HoleData f p = Outer !f | Hole !f !p deriving (Show,Eq)
 
-holeData            :: HoleData f p -> f
-holeData (Outer f)  = f
-holeData (Hole f _) = f
+_holeData            :: HoleData f p -> f
+_holeData (Outer f)  = f
+_holeData (Hole f _) = f
 
-getP            :: HoleData f p -> Maybe p
-getP (Outer _)  = Nothing
-getP (Hole _ p) = Just p
+_getP            :: HoleData f p -> Maybe p
+_getP (Outer _)  = Nothing
+_getP (Hole _ p) = Just p
 
 --------------------------------------------------------------------------------
 

--- a/hgeometry/src/Data/Geometry/PlanarSubdivision/Merge.hs
+++ b/hgeometry/src/Data/Geometry/PlanarSubdivision/Merge.hs
@@ -221,12 +221,14 @@ data Id a = Id a
 triangle1 :: PlanarSubdivision Test () () Int Rational
 triangle1 = (\pg -> fromSimplePolygon (Id Test) pg 1 0)
           $ trianglePG1
+trianglePG1 :: SimplePolygon () Rational
 trianglePG1 = fromPoints . map ext $ [origin, Point2 200 0, Point2 200 200]
 
 
 triangle2 :: PlanarSubdivision Test () () Int Rational
 triangle2 = (\pg -> fromSimplePolygon (Id Test) pg 2 0)
           $ trianglePG2
+trianglePG2 :: SimplePolygon () Rational
 trianglePG2 = fromPoints . map ext $ [Point2 0 30, Point2 10 30, Point2 10 40]
 
 
@@ -234,15 +236,18 @@ trianglePG2 = fromPoints . map ext $ [Point2 0 30, Point2 10 30, Point2 10 40]
 triangle4 :: PlanarSubdivision Test () () Int Rational
 triangle4 = (\pg -> fromSimplePolygon (Id Test) pg 1 0)
           $ trianglePG4
+trianglePG4 :: SimplePolygon () Rational
 trianglePG4 = fromPoints . map ext $ [Point2 400 400, Point2 600 400, Point2 600 600]
 
 triangle3 :: PlanarSubdivision Test () () Int Rational
 triangle3 = (\pg -> fromSimplePolygon (Id Test) pg 3 0)
           $ trianglePG3
+trianglePG3 :: SimplePolygon () Rational
 trianglePG3 = fromPoints . map ext $ [Point2 401 530, Point2 410 530, Point2 410 540]
 
 
-myPS = embedAsHoleIn triangle2 const (mkFI 1) triangle1
+_myPS :: PlanarSubdivision Test () () Int Rational
+_myPS = embedAsHoleIn triangle2 const (mkFI 1) triangle1
        `merge`
        embedAsHoleIn triangle3 const (mkFI 1) triangle4
 

--- a/hgeometry/src/Data/Geometry/Point/Quadrants.hs
+++ b/hgeometry/src/Data/Geometry/Point/Quadrants.hs
@@ -1,26 +1,13 @@
 module Data.Geometry.Point.Quadrants where
 
-import           Control.DeepSeq
 import           Control.Lens
-import           Data.Aeson
 import           Data.Ext
-import qualified Data.Foldable as F
 import           Data.Geometry.Point.Class
 import           Data.Geometry.Point.Internal
-import           Data.Geometry.Properties
 import           Data.Geometry.Vector
-import qualified Data.Geometry.Vector as Vec
-import           Data.Hashable
 import qualified Data.List as L
-import           Data.Ord (comparing)
-import           Data.Proxy
-import           GHC.Generics (Generic)
 import           GHC.TypeLits
-import           System.Random (Random(..))
-import           Test.QuickCheck (Arbitrary)
-import           Text.ParserCombinators.ReadP (ReadP, string,pfail)
-import           Text.ParserCombinators.ReadPrec (lift)
-import           Text.Read (Read(..),readListPrecDefault, readPrec_to_P,minPrec)
+import           Text.Read (Read(..))
 
 --------------------------------------------------------------------------------
 

--- a/hgeometry/src/Data/Geometry/RangeTree.hs
+++ b/hgeometry/src/Data/Geometry/RangeTree.hs
@@ -13,8 +13,6 @@ import qualified Data.List.NonEmpty as NonEmpty
 import           Data.Measured.Class
 import           Data.Proxy
 import           Data.Range
-import           Data.Semigroup.Foldable
-import           Data.Vector.Fixed.Cont (Peano, PeanoNum(..))
 import           GHC.TypeLits
 import           Prelude hiding (last,init,head)
 

--- a/hgeometry/src/Data/Geometry/RangeTree/Generic.hs
+++ b/hgeometry/src/Data/Geometry/RangeTree/Generic.hs
@@ -3,7 +3,6 @@ module Data.Geometry.RangeTree.Generic where
 import           Control.Lens
 import           Data.BinaryTree
 import           Data.Ext
-import           Data.Geometry.Point
 import           Data.Geometry.Properties
 import           Data.Geometry.RangeTree.Measure
 import           Data.List.NonEmpty (NonEmpty(..))
@@ -13,7 +12,6 @@ import           Data.Measured.Class
 import           Data.Measured.Size
 import           Data.Semigroup
 import           Data.Semigroup.Foldable
-import qualified Data.Set as Set
 import           Data.Util
 
 --------------------------------------------------------------------------------

--- a/hgeometry/src/Data/Geometry/RangeTree/Measure.hs
+++ b/hgeometry/src/Data/Geometry/RangeTree/Measure.hs
@@ -1,3 +1,4 @@
+{-# OPTIONS_GHC -Wno-orphans #-}
 module Data.Geometry.RangeTree.Measure where
 
 import Data.Measured.Class

--- a/hgeometry/src/Data/Geometry/SegmentTree/Generic.hs
+++ b/hgeometry/src/Data/Geometry/SegmentTree/Generic.hs
@@ -121,6 +121,7 @@ fromIntervals      :: (Ord r, Eq p, Assoc v i, IntervalLike i, Monoid v, NumType
 fromIntervals f is = foldr (insert . f) (createTree pts mempty) is
   where
     endPoints (asRange -> Range' a b) = [a,b]
+    endPoints _ = error "Unreachable, but cannot prove it in Haskell"
     pts = nub' . NonEmpty.sort . NonEmpty.fromList . concatMap endPoints $ is
     nub' = fmap NonEmpty.head . NonEmpty.group1
 


### PR DESCRIPTION
 * Remove unused imports.
 * Add missing top-level type signatures.
 * Mark unused functions with underscore.
 * Complete pattern matches.
 * Suppress warnings about orphans.