### PR TITLE
Include doctest in CI runs.

### DIFF
--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -40,6 +40,7 @@ jobs:
     - name: Build
       run: cabal v2-build hgeometry-test
     - name: Test hgeometry
+      if: ${{ !(matrix.os == 'macOS-latest' && matrix.ghc == '8.4') }}
       run: |
         cabal v2-build hgeometry
         cabal v2-test --test-show-details=always hgeometry

--- a/.github/workflows/cabal.yml
+++ b/.github/workflows/cabal.yml
@@ -39,7 +39,11 @@ jobs:
         cabal v2-build --only-dependencies --enable-tests --enable-benchmarks hgeometry-test
     - name: Build
       run: cabal v2-build hgeometry-test
-    - name: Test
+    - name: Test hgeometry
+      run: |
+        cabal v2-build hgeometry
+        cabal v2-test --test-show-details=always hgeometry
+    - name: Test integration
       run: |
         cabal v2-test --test-show-details=always hgeometry-test
     # - name: Check documentation syntax

--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,4 @@
+write-ghc-environment-files: always
 tests: true
 packages:
     hgeometry

--- a/hgeometry/hgeometry.cabal
+++ b/hgeometry/hgeometry.cabal
@@ -296,13 +296,16 @@ library
                     , FlexibleContexts
                     , MultiParamTypeClasses
 
-test-suite doctests
-  type:          exitcode-stdio-1.0
-  ghc-options:   -threaded
-  main-is:       doctests.hs
-  build-depends: base
-               , doctest             >= 0.8
-               , doctest-discover
-               , QuickCheck
-
-  default-language:    Haskell2010
+-- doctest is poorly supported with newer versions of ghc and cabal.
+-- Disabled 2020-11-11
+-- test-suite doctests
+--   type:          exitcode-stdio-1.0
+--   ghc-options:   -threaded
+--   main-is:       doctests.hs
+--   build-depends: base
+--                , doctest             >= 0.8
+--                , doctest-discover
+--                , QuickCheck
+--                , quickcheck-instances
+--
+--   default-language:    Haskell2010

--- a/hgeometry/hgeometry.cabal
+++ b/hgeometry/hgeometry.cabal
@@ -296,16 +296,14 @@ library
                     , FlexibleContexts
                     , MultiParamTypeClasses
 
--- doctest is poorly supported with newer versions of ghc and cabal.
--- Disabled 2020-11-11
--- test-suite doctests
---   type:          exitcode-stdio-1.0
---   ghc-options:   -threaded
---   main-is:       doctests.hs
---   build-depends: base
---                , doctest             >= 0.8
---                , doctest-discover
---                , QuickCheck
---                , quickcheck-instances
---
---   default-language:    Haskell2010
+test-suite doctests
+  type:          exitcode-stdio-1.0
+  ghc-options:   -threaded
+  main-is:       doctests.hs
+  build-depends: base
+               , doctest             >= 0.8
+               , doctest-discover
+               , QuickCheck
+               , quickcheck-instances
+
+  default-language:    Haskell2010


### PR DESCRIPTION
It would be nice to get this up and running again but doctest is apparently not supported on ghc >=8.8.