### PR TITLE
Random ConvexPolygon in O(n log n)

### DIFF
--- a/hgeometry-test/src/Data/Geometry/PointSpec.hs
+++ b/hgeometry-test/src/Data/Geometry/PointSpec.hs
@@ -23,59 +23,60 @@ spec = do
 
   describe "cmpAroundWith tests" $ do
     it "ccw same as by quarant " $
-      property $ \(c :: Point 2 Int :+ ()) (p :: Point 2 Int :+ ()) (q :: Point 2 Int :+ ()) ->
-        (p /= c && q /= c) ==> ccwCmpAround c p q == ccwCmpAroundByQuadrant c p q
+      property $ \(c :: Point 2 Int) (p :: Point 2 Int) (q :: Point 2 Int) ->
+        (p /= c && q /= c) ==> ccwCmpAround c p q == ccwCmpAroundByQuadrant (ext c) (ext p) (ext q)
     it "cw same as by quarant " $
-      property $ \(c :: Point 2 Int :+ ()) (p :: Point 2 Int :+ ()) (q :: Point 2 Int :+ ()) ->
-        (p /= c && q /= c) ==> cwCmpAround c p q == cwCmpAroundByQuadrant c p q
+      property $ \(c :: Point 2 Int) (p :: Point 2 Int) (q :: Point 2 Int) ->
+        (p /= c && q /= c) ==> cwCmpAround c p q == cwCmpAroundByQuadrant (ext c) (ext p) (ext q)
 
     it "cw same as by quarant with distance " $ do
       let cwCmpAroundWithDist c p q = cwCmpAround c p q <> cmpByDistanceTo c p q
-      property $ \(c :: Point 2 Int :+ ()) (p :: Point 2 Int :+ ()) (q :: Point 2 Int :+ ()) ->
-        (p /= c && q /= c) ==> cwCmpAroundWithDist c p q == cwCmpAroundByQuadrantWithDist c p q
+      property $ \(c :: Point 2 Int) (p :: Point 2 Int) (q :: Point 2 Int) ->
+        (p /= c && q /= c) ==>
+        cwCmpAroundWithDist c p q == cwCmpAroundByQuadrantWithDist (ext c) (ext p) (ext q)
 
   describe "Sort Arround a Point test" $ do
     it "Sort around origin" $
-      sortAround (ext origin) (map ext [ Point2 (-3) (-3)
-                                       , Point2 (-1) (-5)
-                                       , Point2 5    5
-                                       , Point2 6    (-4)
-                                       , Point2 (-5) 3
-                                       , Point2 10   1
-                                       , Point2 20   0
-                                       , Point2 0    (-6)
-                                       , Point2 5    7
-                                       , Point2 5    5
-                                       , Point2 2    2
-                                       , Point2 26   (-2)
-                                       , Point2 0    (-5)
-                                        ])
-      `shouldBe` map ext [ Point2 20   0
-                         , Point2 10   1
-                         , Point2 2    2
-                         , Point2 5    5
-                         , Point2 5    5
-                         , Point2 5    7
-                         , Point2 (-5) 3
-                         , Point2 (-3) (-3)
-                         , Point2 (-1) (-5)
-                         , Point2 0    (-5)
-                         , Point2 0    (-6)
-                         , Point2 6    (-4)
-                         , Point2 26   (-2)
+      sortAround origin [ Point2 (-3) (-3)
+                        , Point2 (-1) (-5)
+                        , Point2 5    5
+                        , Point2 6    (-4)
+                        , Point2 (-5) 3
+                        , Point2 10   1
+                        , Point2 20   0
+                        , Point2 0    (-6)
+                        , Point2 5    7
+                        , Point2 5    5
+                        , Point2 2    2
+                        , Point2 26   (-2)
+                        , Point2 0    (-5)
                          ]
+      `shouldBe` [ Point2 20   0
+                 , Point2 10   1
+                 , Point2 2    2
+                 , Point2 5    5
+                 , Point2 5    5
+                 , Point2 5    7
+                 , Point2 (-5) 3
+                 , Point2 (-3) (-3)
+                 , Point2 (-1) (-5)
+                 , Point2 0    (-5)
+                 , Point2 0    (-6)
+                 , Point2 6    (-4)
+                 , Point2 26   (-2)
+                 ]
     it "degenerate points on horizontal line" $
-      sortAround (ext origin) (map ext [ Point2 2    0
-                                       , Point2 (-1) 0
-                                       , Point2 10   0
-                                       ])
-      `shouldBe` map ext [ Point2 2 0, Point2 10 0, Point2 (-1) 0 ]
+      sortAround origin [ Point2 2    0
+                        , Point2 (-1) 0
+                        , Point2 10   0
+                        ]
+      `shouldBe` [ Point2 2 0, Point2 10 0, Point2 (-1) 0 ]
     it "degenerate points on vertical line" $
-      sortAround (ext origin) (map ext [ Point2 0 2
-                                       , Point2 0 (-1)
-                                       , Point2 0 10
-                                       ])
-      `shouldBe` map ext [ Point2 0 2, Point2 0 10, Point2 0 (-1) ]
+      sortAround origin [ Point2 0 2
+                        , Point2 0 (-1)
+                        , Point2 0 10
+                        ]
+      `shouldBe` [ Point2 0 2, Point2 0 10, Point2 0 (-1) ]
 
 
   describe "Insert point in ciclically ordered list" $ do

--- a/hgeometry/src/Algorithms/Geometry/ConvexHull/JarvisMarch.hs
+++ b/hgeometry/src/Algorithms/Geometry/ConvexHull/JarvisMarch.hs
@@ -99,13 +99,13 @@ lowerHull' pts = pruneVertical $ repeatedly cmp steepestCcwFrom s rest
 -- with minimum slope w.r.t. the given point.
 steepestCcwFrom   :: (Ord r, Num r)
                => (Point 2 r :+ a) -> NonEmpty (Point 2 r :+ b)  -> Point 2 r :+ b
-steepestCcwFrom p = List.minimumBy (ccwCmpAroundWith (Vector2 0 (-1)) p)
+steepestCcwFrom p = List.minimumBy (ccwCmpAroundWith' (Vector2 0 (-1)) p)
 
 -- | Find the next point in clockwise order, i.e. the point
 -- with maximum slope w.r.t. the given point.
 steepestCwFrom   :: (Ord r, Num r)
                => (Point 2 r :+ a) -> NonEmpty (Point 2 r :+ b)  -> Point 2 r :+ b
-steepestCwFrom p = List.minimumBy (cwCmpAroundWith (Vector2 0 1) p)
+steepestCwFrom p = List.minimumBy (cwCmpAroundWith' (Vector2 0 1) p)
 
 repeatedly       :: (a -> a -> Ordering) -> (a -> NonEmpty a -> a) -> a -> [a] -> NonEmpty a
 repeatedly cmp f = go

--- a/hgeometry/src/Algorithms/Geometry/DelaunayTriangulation/DivideAndConquer.hs
+++ b/hgeometry/src/Algorithms/Geometry/DelaunayTriangulation/DivideAndConquer.hs
@@ -25,7 +25,6 @@ import qualified Data.Foldable                                   as F
 import           Data.Function                                   (on)
 import           Data.Geometry                                   hiding (rotateTo)
 import           Data.Geometry.Ball                              (disk, insideBall)
-import           Data.Geometry.Polygon
 import           Data.Geometry.Polygon.Convex                    (ConvexPolygon (..), simplePolygon)
 import qualified Data.Geometry.Polygon.Convex                    as Convex
 import qualified Data.IntMap.Strict                              as IM
@@ -243,8 +242,8 @@ insert' u v (_,ptMap) = IM.adjustWithKey (insert'' v) u
                       . IM.adjustWithKey (insert'' u) v
   where
     -- inserts b into the adjacency list of a
-    insert'' bi ai = CU.insertOrdBy (cwCmpAround' (ptMap V.! ai) `on` (ptMap V.!)) bi
-    cwCmpAround' c p q = cwCmpAround c p q <> cmpByDistanceTo c p q
+    insert'' bi ai = CU.insertOrdBy (cmp (ptMap V.! ai) `on` (ptMap V.!)) bi
+    cmp c p q = cwCmpAround' c p q <> cmpByDistanceTo' c p q
 
 
 -- | Deletes an edge

--- a/hgeometry/src/Algorithms/Geometry/DelaunayTriangulation/Naive.hs
+++ b/hgeometry/src/Algorithms/Geometry/DelaunayTriangulation/Naive.hs
@@ -59,14 +59,14 @@ toAdjLists m@(_,ptsV) es = V.imap toCList $ V.create $ do
     addAt    v i j = updateAt v i (j:)
 
     -- convert to a CList, sorted in CCW order around point u
-    toCList u = C.fromList . sortAround' m u
+    toCList u = C.fromList . sortAroundMapping m u
 
 -- | Given a particular point u and a list of points vs, sort the points vs in
 -- CW order around u.
 -- running time: O(m log m), where m=|vs| is the number of vertices to sort.
-sortAround'               :: (Num r, Ord r)
+sortAroundMapping               :: (Num r, Ord r)
                           => Mapping p r -> VertexID -> [VertexID] -> [VertexID]
-sortAround' (_,ptsV) u vs = reverse . map (^.extra) $ sortAround (f u) (map f vs)
+sortAroundMapping (_,ptsV) u vs = reverse . map (^.extra) $ sortAround' (f u) (map f vs)
   where
     f v = (ptsV V.! v)&extra .~ v
 

--- a/hgeometry/src/Algorithms/Geometry/SSSP/Naive.hs
+++ b/hgeometry/src/Algorithms/Geometry/SSSP/Naive.hs
@@ -18,7 +18,7 @@ import           Data.Ext                  (_core, core)
 import qualified Data.Foldable             as F
 import           Data.Geometry.Interval    (EndPoint (Closed, Open), end, start)
 import           Data.Geometry.LineSegment (LineSegment (..), sqSegmentLength)
-import           Data.Geometry.Point       (ccwCmpAroundWith)
+import           Data.Geometry.Point       (ccwCmpAroundWith')
 import           Data.Geometry.Polygon     (SimplePolygon, listEdges, outerBoundaryVector)
 import           Data.Intersection         (IsIntersectableWith (intersect),
                                             NoIntersection (NoIntersection))
@@ -62,7 +62,7 @@ visibleEdges p = concat
     , let endPt = CV.index vs j
     , let line = LineSegment (Closed pt) (Open endPt)
       -- Check if the line goes through the inside of the polygon.
-    , ccwCmpAroundWith ((_core prev) .-. (_core pt)) pt endPt next == GT
+    , ccwCmpAroundWith' ((_core prev) .-. (_core pt)) pt endPt next == GT
       -- Check if there are any intersections not the line end points.
     , not (interiorIntersection line edges)
     ]

--- a/hgeometry/src/Data/Geometry/Point.hs
+++ b/hgeometry/src/Data/Geometry/Point.hs
@@ -22,12 +22,16 @@ module Data.Geometry.Point( Point(.., Point1, Point2, Point3)
                           , CCW, ccw, ccw'
                           , pattern CCW, pattern CW, pattern CoLinear
 
-                          , ccwCmpAround, cwCmpAround, ccwCmpAroundWith, cwCmpAroundWith
-                          , sortAround, insertIntoCyclicOrder
+                          , ccwCmpAround, ccwCmpAround'
+                          , cwCmpAround, cwCmpAround'
+                          , ccwCmpAroundWith, ccwCmpAroundWith'
+                          , cwCmpAroundWith, cwCmpAroundWith'
+                          , sortAround, sortAround'
+                          , insertIntoCyclicOrder
 
                           , Quadrant(..), quadrantWith, quadrant, partitionIntoQuadrants
 
-                          , cmpByDistanceTo
+                          , cmpByDistanceTo, cmpByDistanceTo'
 
                           , squaredEuclideanDist, euclideanDist
 

--- a/hgeometry/src/Data/Geometry/Point/Internal.hs
+++ b/hgeometry/src/Data/Geometry/Point/Internal.hs
@@ -25,6 +25,7 @@ module Data.Geometry.Point.Internal
   , PointFunctor(..)
 
   , cmpByDistanceTo
+  , cmpByDistanceTo'
   , squaredEuclideanDist, euclideanDist
   ) where
 
@@ -115,6 +116,7 @@ deriving instance (Eq r, Arity d)        => Eq (Point d r)
 deriving instance Arity d                => Eq1 (Point d)
 deriving instance (Ord r, Arity d)       => Ord (Point d r)
 deriving instance Arity d                => Functor (Point d)
+deriving instance Arity d                => Applicative (Point d)
 deriving instance Arity d                => Foldable (Point d)
 deriving instance Arity d                => Traversable (Point d)
 deriving instance (Arity d, NFData r)    => NFData (Point d r)
@@ -126,6 +128,14 @@ deriving instance (Arity d, Random r)    => Random (Point d r)
 
 type instance NumType (Point d r) = r
 type instance Dimension (Point d r) = d
+
+instance Arity d => Additive (Point d) where
+  zero = origin
+  p ^+^ q = Point $ toVec p ^+^ toVec q
+  p ^-^ q = Point $ toVec p ^-^ toVec q
+  lerp i a b = Point $ lerp i (toVec a) (toVec b)
+  liftU2 app a b = Point $ liftU2 app (toVec a) (toVec b)
+  liftI2 app a b = Point $ liftI2 app (toVec a) (toVec b)
 
 instance Arity d =>  Affine (Point d) where
   type Diff (Point d) = Vector d
@@ -245,9 +255,13 @@ instance PointFunctor (Point d) where
 
 -- | Compare by distance to the first argument
 cmpByDistanceTo              :: (Ord r, Num r, Arity d)
-                             => Point d r :+ c -> Point d r :+ p -> Point d r :+ q -> Ordering
-cmpByDistanceTo (c :+ _) p q = comparing (squaredEuclideanDist c) (p^.core) (q^.core)
+                             => Point d r -> Point d r -> Point d r -> Ordering
+cmpByDistanceTo c p q = comparing (squaredEuclideanDist c) p q
 
+-- | Compare by distance to the first argument
+cmpByDistanceTo'  :: (Ord r, Num r, Arity d)
+                  => Point d r :+ c -> Point d r :+ p -> Point d r :+ q -> Ordering
+cmpByDistanceTo' c p q = cmpByDistanceTo (c^.core) (p^.core) (q^.core)
 
 
 

--- a/hgeometry/src/Data/Geometry/Point/Internal.hs
+++ b/hgeometry/src/Data/Geometry/Point/Internal.hs
@@ -129,14 +129,6 @@ deriving instance (Arity d, Random r)    => Random (Point d r)
 type instance NumType (Point d r) = r
 type instance Dimension (Point d r) = d
 
-instance Arity d => Additive (Point d) where
-  zero = origin
-  p ^+^ q = Point $ toVec p ^+^ toVec q
-  p ^-^ q = Point $ toVec p ^-^ toVec q
-  lerp i a b = Point $ lerp i (toVec a) (toVec b)
-  liftU2 app a b = Point $ liftU2 app (toVec a) (toVec b)
-  liftI2 app a b = Point $ liftI2 app (toVec a) (toVec b)
-
 instance Arity d =>  Affine (Point d) where
   type Diff (Point d) = Vector d
 

--- a/hgeometry/src/Data/Geometry/Point/Orientation/Degenerate.hs
+++ b/hgeometry/src/Data/Geometry/Point/Orientation/Degenerate.hs
@@ -4,10 +4,12 @@ module Data.Geometry.Point.Orientation.Degenerate(
 
   , ccw, ccw'
 
-  , sortAround
+  , sortAround, sortAround'
 
-  , ccwCmpAroundWith, cwCmpAroundWith
-  , ccwCmpAround, cwCmpAround
+  , ccwCmpAroundWith, ccwCmpAroundWith'
+  , cwCmpAroundWith, cwCmpAroundWith'
+  , ccwCmpAround, ccwCmpAround'
+  , cwCmpAround, cwCmpAround'
 
   , insertIntoCyclicOrder
   ) where
@@ -67,8 +69,16 @@ ccw' p q r = ccw (p^.core) (q^.core) (r^.core)
 -- and r are colinear with p, the closest one to p is reported first.
 -- running time: O(n log n)
 sortAround   :: (Ord r, Num r)
-             => Point 2 r :+ q -> [Point 2 r :+ p] -> [Point 2 r :+ p]
+             => Point 2 r -> [Point 2 r] -> [Point 2 r]
 sortAround c = L.sortBy (ccwCmpAround c <> cmpByDistanceTo c)
+
+-- | Sort the points arround the given point p in counter clockwise order with
+-- respect to the rightward horizontal ray starting from p.  If two points q
+-- and r are colinear with p, the closest one to p is reported first.
+-- running time: O(n log n)
+sortAround'   :: (Ord r, Num r)
+             => Point 2 r :+ q -> [Point 2 r :+ p] -> [Point 2 r :+ p]
+sortAround' c = L.sortBy (ccwCmpAround' c <> cmpByDistanceTo' c)
 
 
 -- | Given a zero vector z, a center c, and two points p and q,
@@ -78,10 +88,10 @@ sortAround c = L.sortBy (ccwCmpAround c <> cmpByDistanceTo c)
 -- pre: the points p,q /= c
 ccwCmpAroundWith                              :: (Ord r, Num r)
                                               => Vector 2 r
-                                              -> Point 2 r :+ c
-                                              -> Point 2 r :+ a -> Point 2 r :+ b
+                                              -> Point 2 r
+                                              -> Point 2 r -> Point 2 r
                                               -> Ordering
-ccwCmpAroundWith z@(Vector2 zx zy) (c :+ _) (q :+ _) (r :+ _) =
+ccwCmpAroundWith z@(Vector2 zx zy) c q r =
     case (ccw c a q, ccw c a r) of
       (CCW,CCW)      -> cmp
       (CCW,CW)       -> LT
@@ -117,6 +127,13 @@ ccwCmpAroundWith z@(Vector2 zx zy) (c :+ _) (q :+ _) (r :+ _) =
             CW       -> GT
             CoLinear -> EQ
 
+ccwCmpAroundWith'                             :: (Ord r, Num r)
+                                              => Vector 2 r
+                                              -> Point 2 r :+ c
+                                              -> Point 2 r :+ a -> Point 2 r :+ b
+                                              -> Ordering
+ccwCmpAroundWith' z (c :+ _) (q :+ _) (r :+ _) = ccwCmpAroundWith z c q r
+
 -- | Given a zero vector z, a center c, and two points p and q,
 -- compute the cw ordering of p and q around c with this vector as zero
 -- direction.
@@ -124,23 +141,41 @@ ccwCmpAroundWith z@(Vector2 zx zy) (c :+ _) (q :+ _) (r :+ _) =
 -- pre: the points p,q /= c
 cwCmpAroundWith     :: (Ord r, Num r)
                     => Vector 2 r
+                    -> Point 2 r
+                    -> Point 2 r -> Point 2 r
+                    -> Ordering
+cwCmpAroundWith z c = flip (ccwCmpAroundWith z c)
+
+cwCmpAroundWith'    :: (Ord r, Num r)
+                    => Vector 2 r
                     -> Point 2 r :+ a
                     -> Point 2 r :+ b -> Point 2 r :+ c
                     -> Ordering
-cwCmpAroundWith z c = flip (ccwCmpAroundWith z c)
+cwCmpAroundWith' z c = flip (ccwCmpAroundWith' z c)
 
 -- | Counter clockwise ordering of the points around c. Points are ordered with
 -- respect to the positive x-axis.
 ccwCmpAround :: (Num r, Ord r)
-             => Point 2 r :+ qc -> Point 2 r :+ p -> Point 2 r :+ q -> Ordering
+             => Point 2 r -> Point 2 r -> Point 2 r -> Ordering
 ccwCmpAround = ccwCmpAroundWith (Vector2 1 0)
+
+-- | Counter clockwise ordering of the points around c. Points are ordered with
+-- respect to the positive x-axis.
+ccwCmpAround' :: (Num r, Ord r)
+             => Point 2 r :+ qc -> Point 2 r :+ p -> Point 2 r :+ q -> Ordering
+ccwCmpAround' = ccwCmpAroundWith' (Vector2 1 0)
 
 -- | Clockwise ordering of the points around c. Points are ordered with
 -- respect to the positive x-axis.
 cwCmpAround :: (Num r, Ord r)
-            => Point 2 r :+ qc -> Point 2 r :+ p -> Point 2 r :+ q -> Ordering
+            => Point 2 r -> Point 2 r -> Point 2 r -> Ordering
 cwCmpAround = cwCmpAroundWith (Vector2 1 0)
 
+-- | Clockwise ordering of the points around c. Points are ordered with
+-- respect to the positive x-axis.
+cwCmpAround' :: (Num r, Ord r)
+            => Point 2 r :+ qc -> Point 2 r :+ p -> Point 2 r :+ q -> Ordering
+cwCmpAround' a b c = cwCmpAround (a^.core) (b^.core) (c^.core)
 
 -- | Given a center c, a new point p, and a list of points ps, sorted in
 -- counter clockwise order around c. Insert p into the cyclic order. The focus
@@ -150,4 +185,4 @@ cwCmpAround = cwCmpAroundWith (Vector2 1 0)
 insertIntoCyclicOrder   :: (Ord r, Num r)
                         => Point 2 r :+ q -> Point 2 r :+ p
                         -> C.CList (Point 2 r :+ p) -> C.CList (Point 2 r :+ p)
-insertIntoCyclicOrder c = CU.insertOrdBy (ccwCmpAround c <> cmpByDistanceTo c)
+insertIntoCyclicOrder c = CU.insertOrdBy (ccwCmpAround' c <> cmpByDistanceTo' c)

--- a/hgeometry/src/Data/PlaneGraph/Core.hs
+++ b/hgeometry/src/Data/PlaneGraph/Core.hs
@@ -220,7 +220,7 @@ fromConnectedSegments _ ss = PlaneGraph $ planarGraph dts & PG.vertexData .~ vxD
 
     sing x = x NonEmpty.:| []
 
-    vts    = map (\(p,sp) -> (p,map (^.extra) . sortAround (ext p) <$> sp))
+    vts    = map (\(p,sp) -> (p,map (^.extra) . sortAround' (ext p) <$> sp))
            . M.assocs $ pts
     -- vertex Data
     vxData = V.fromList . map (\(p,sp) -> VertexData p (sp^._1)) $ vts

--- a/hgeometry/src/Data/PlaneGraph/IO.hs
+++ b/hgeometry/src/Data/PlaneGraph/IO.hs
@@ -16,7 +16,6 @@ import           Control.Monad (forM_)
 import           Data.Aeson
 import           Data.Bifunctor
 import qualified Data.ByteString as B
-import           Data.Ext
 import           Data.Geometry.Point
 import qualified Data.List as List
 import qualified Data.PlanarGraph.AdjRep as PGA
@@ -123,11 +122,11 @@ makeCCW (Gr vs fs) = Gr (map sort' vs) fs
     location' = V.create $ do
                    a <- MV.new (length vs)
                    forM_ vs $ \(Vtx i p _ _) ->
-                     MV.write a i $ ext p
+                     MV.write a i p
                    pure a
     -- sort the adjacencies around every vertex v
     sort' (Vtx v p ajs x) = Vtx v p (List.sortBy (around p) ajs) x
-    around p (a,_) (b,_) = ccwCmpAround (ext p) (location' V.! a) (location' V.! b)
+    around p (a,_) (b,_) = ccwCmpAround p (location' V.! a) (location' V.! b)
                            -- note: since the graph is planar, there should not be
                            -- any pairs of points for which ccwCmpAround returns EQ
                            -- hence, no need to pick a secondary comparison


### PR DESCRIPTION
This PR includes:
 - Point orientation functions that operate without Data.Ext. Style matches `ccw/ccw'`: `sortAround/sortAround'`, 'ccwCmpAround/ccwCmpAround'`, etc.
 - `Applicative` and `Additive` instances for `Point`. Is there a reason not to have these?
 - A random generator for ConvexPolygon in `O(n log n)`.