### PR TITLE
Read/Show improvements.

### DIFF
--- a/hgeometry-combinatorial/hgeometry-combinatorial.cabal
+++ b/hgeometry-combinatorial/hgeometry-combinatorial.cabal
@@ -216,6 +216,7 @@ test-suite hspec
                  Data.OrdSeqSpec
                  Data.CircularSeqSpec
                  Data.IndexedDoublyLinkedListSpec
+                 Data.RealNumber.RationalSpec
 
 
   build-depends:        base

--- a/hgeometry-combinatorial/src/Data/RealNumber/Rational.hs
+++ b/hgeometry-combinatorial/src/Data/RealNumber/Rational.hs
@@ -47,7 +47,7 @@ instance KnownNat p => HasResolution (NatPrec p) where
 
 
 instance KnownNat p => Show (RealNumber p) where
-  showsPrec d r = showParen (d > app_prec) $
+  showsPrec d r = showParen (d > app_prec && r < 0) $
     case asFixed r of
       Exact p -> showString (dropWhileEnd (== '.') . dropWhileEnd (== '0') . show $ p)
       Lossy p -> shows p . showChar '~'

--- a/hgeometry-combinatorial/src/Data/RealNumber/Rational.hs
+++ b/hgeometry-combinatorial/src/Data/RealNumber/Rational.hs
@@ -43,13 +43,16 @@ newtype RealNumber (p :: Nat) = RealNumber Rational
 data NatPrec (p :: Nat) = NatPrec
 
 instance KnownNat p => HasResolution (NatPrec p) where
-  resolution _ = 10 ^ (1 + natVal (NatPrec @p))
+  resolution _ = 10 ^ (natVal (NatPrec @p))
 
 
 instance KnownNat p => Show (RealNumber p) where
-  show r = case asFixed r of
-             Exact p -> dropWhileEnd (== '.') . dropWhileEnd (== '0') . show $ p
-             Lossy p -> (<> "~")                                      . show $ p
+  showsPrec d r = showParen (d > app_prec) $
+    case asFixed r of
+      Exact p -> showString (dropWhileEnd (== '.') . dropWhileEnd (== '0') . show $ p)
+      Lossy p -> shows p . showChar '~'
+    where
+      app_prec = 10
 
 instance KnownNat p => Read (RealNumber p) where
   readsPrec i = map wrap . readsPrec @(Fixed (NatPrec p)) i

--- a/hgeometry-combinatorial/test/Data/RealNumber/RationalSpec.hs
+++ b/hgeometry-combinatorial/test/Data/RealNumber/RationalSpec.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE DataKinds #-}
+module Data.RealNumber.RationalSpec where
+
+import           Data.RealNumber.Rational
+import           Test.Hspec
+import           Test.QuickCheck
+
+type R = RealNumber 5
+
+spec :: Spec
+spec = do
+  describe "Read/Show" $ do
+    it "read basic" $ do
+      read (show (1::R)) `shouldBe` (1::R)
+      read (show (negate 1::R)) `shouldBe` negate (1::R)
+    it "read nested" $ do
+      read (show (Just (1::R))) `shouldBe` Just (1::R)
+      read (show (Just (negate 1::R))) `shouldBe` Just (negate (1::R))
+    specify "significant digits" $ do
+      show (0.12345::RealNumber 2) `shouldBe` "0.12~"
+      show (0.12345::RealNumber 5) `shouldBe` "0.12345"
+    it "should discard tail" $ do
+      read (show (0.12345::RealNumber 2)) `shouldBe` (0.12 ::R)
+      reads "0.12345~" `shouldBe` [(0.12::RealNumber 2, "")]
+

--- a/hgeometry-test/src/Data/Geometry/PointSpec.hs
+++ b/hgeometry-test/src/Data/Geometry/PointSpec.hs
@@ -121,3 +121,12 @@ spec = do
     property $ qcReadShow1 @(Point 3) Proxy
   specify "Read/Show properties for Point4" $
     property $ qcReadShow1 @(Point 4) Proxy
+
+  specify "Read/Show properties for Vector1" $
+    property $ qcReadShow1 @(Vector 1) Proxy
+  specify "Read/Show properties for Vector2" $
+    property $ qcReadShow1 @(Vector 2) Proxy
+  specify "Read/Show properties for Vector3" $
+    property $ qcReadShow1 @(Vector 3) Proxy
+  specify "Read/Show properties for Vector4" $
+    property $ qcReadShow1 @(Vector 4) Proxy

--- a/hgeometry/src/Algorithms/Geometry/ConvexHull/Naive.hs
+++ b/hgeometry/src/Algorithms/Geometry/ConvexHull/Naive.hs
@@ -88,7 +88,7 @@ isValidTriangle t = find (\a -> not $ (a^.core) `intersects` h)
 -- | Computes the halfspace above the triangle.
 --
 -- >>> upperHalfSpaceOf (Triangle (ext $ origin) (ext $ Point3 10 0 0) (ext $ Point3 0 10 0))
--- HalfSpace {_boundingPlane = HyperPlane {_inPlane = Point3 0 0 0, _normalVec = Vector3 [0,0,100]}}
+-- HalfSpace {_boundingPlane = HyperPlane {_inPlane = Point3 0 0 0, _normalVec = Vector3 0 0 100}}
 upperHalfSpaceOf                  :: (Ord r, Num r) => Triangle 3 p r -> HalfSpace 3 r
 upperHalfSpaceOf (Triangle p q r) = HalfSpace h
   where

--- a/hgeometry/src/Data/Geometry/Box/Internal.hs
+++ b/hgeometry/src/Data/Geometry/Box/Internal.hs
@@ -193,7 +193,7 @@ p `inBox` b = FV.and . FV.zipWith R.inRange (toVec p) . extent $ b
 -- starting at zero.
 --
 -- >>> extent (boundingBoxList' [Point3 1 2 3, Point3 10 20 30] :: Box 3 () Int)
--- Vector3 [Range (Closed 1) (Closed 10),Range (Closed 2) (Closed 20),Range (Closed 3) (Closed 30)]
+-- Vector3 (Range (Closed 1) (Closed 10)) (Range (Closed 2) (Closed 20)) (Range (Closed 3) (Closed 30))
 extent                                 :: Arity d
                                        => Box d p r -> Vector d (R.Range r)
 extent (Box (CWMin a :+ _) (CWMax b :+ _)) = FV.zipWith R.ClosedRange (toVec a) (toVec b)
@@ -202,7 +202,7 @@ extent (Box (CWMin a :+ _) (CWMax b :+ _)) = FV.zipWith R.ClosedRange (toVec a) 
 -- whereas one would normally count dimensions starting at zero.
 --
 -- >>> size (boundingBoxList' [origin, Point3 1 2 3] :: Box 3 () Int)
--- Vector3 [1,2,3]
+-- Vector3 1 2 3
 size :: (Arity d, Num r) => Box d p r -> Vector d r
 size = fmap R.width . extent
 

--- a/hgeometry/src/Data/Geometry/HalfSpace.hs
+++ b/hgeometry/src/Data/Geometry/HalfSpace.hs
@@ -71,14 +71,14 @@ type HalfPlane = HalfSpace 2
 -- | Get the halfplane left of a line (i.e. "above") a line
 --
 -- >>> leftOf $ horizontalLine 4
--- HalfSpace {_boundingPlane = HyperPlane {_inPlane = Point2 0 4, _normalVec = Vector2 [0,1]}}
+-- HalfSpace {_boundingPlane = HyperPlane {_inPlane = Point2 0 4, _normalVec = Vector2 0 1}}
 leftOf   :: Num r => Line 2 r -> HalfPlane r
 leftOf l = (rightOf l)&boundingPlane.normalVec %~ ((-1) *^)
 
 -- | Get the halfplane right of a line (i.e. "below") a line
 --
 -- >>> rightOf $ horizontalLine 4
--- HalfSpace {_boundingPlane = HyperPlane {_inPlane = Point2 0 4, _normalVec = Vector2 [0,-1]}}
+-- HalfSpace {_boundingPlane = HyperPlane {_inPlane = Point2 0 4, _normalVec = Vector2 0 (-1)}}
 rightOf   :: Num r => Line 2 r -> HalfPlane r
 rightOf l = HalfSpace $ l^.re _asLine
 

--- a/hgeometry/src/Data/Geometry/HyperPlane.hs
+++ b/hgeometry/src/Data/Geometry/HyperPlane.hs
@@ -84,7 +84,7 @@ pattern Plane p n = HyperPlane p n
 -- the normal vector of the resulting plane is pointing "upwards".
 --
 -- >>> from3Points origin (Point3 1 0 0) (Point3 0 1 0)
--- HyperPlane {_inPlane = Point3 0 0 0, _normalVec = Vector3 [0,0,1]}
+-- HyperPlane {_inPlane = Point3 0 0 0, _normalVec = Vector3 0 0 1}
 from3Points       :: Num r => Point 3 r -> Point 3 r -> Point 3 r -> HyperPlane 3 r
 from3Points p q r = let u = q .-. p
                         v = r .-. p

--- a/hgeometry/src/Data/Geometry/Line/Internal.hs
+++ b/hgeometry/src/Data/Geometry/Line/Internal.hs
@@ -88,7 +88,7 @@ horizontalLine y = Line (Point2 0 y) (Vector2 1 0)
 -- oriented such that v points into the left halfplane of m.
 --
 -- >>> perpendicularTo $ Line (Point2 3 4) (Vector2 (-1) 2)
--- Line (Point2 3 4) (Vector2 [-2,-1])
+-- Line (Point2 3 4) (Vector2 (-2) (-1))
 perpendicularTo                           :: Num r => Line 2 r -> Line 2 r
 perpendicularTo (Line p ~(Vector2 vx vy)) = Line p (Vector2 (-vy) vx)
 

--- a/hgeometry/src/Data/Geometry/Point/Class.hs
+++ b/hgeometry/src/Data/Geometry/Point/Class.hs
@@ -20,7 +20,7 @@ class AsAPoint p where
 -- | Lens to access the vector corresponding to this point.
 --
 -- >>> (Point3 1 2 3) ^. vector'
--- Vector3 [1,2,3]
+-- Vector3 1 2 3
 -- >>> origin & vector' .~ Vector3 1 2 3
 -- Point3 1 2 3
 vector' :: AsAPoint p => Lens (p d r) (p d r') (Vector d r) (Vector d r')

--- a/hgeometry/src/Data/Geometry/Point/Internal.hs
+++ b/hgeometry/src/Data/Geometry/Point/Internal.hs
@@ -155,7 +155,7 @@ origin = Point $ pure 0
 -- | Lens to access the vector corresponding to this point.
 --
 -- >>> (Point3 1 2 3) ^. vector
--- Vector3 [1,2,3]
+-- Vector3 1 2 3
 -- >>> origin & vector .~ Vector3 1 2 3
 -- Point3 1 2 3
 vector :: Lens (Point d r) (Point d r') (Vector d r) (Vector d r')

--- a/hgeometry/src/Data/Geometry/Polygon.hs
+++ b/hgeometry/src/Data/Geometry/Polygon.hs
@@ -73,8 +73,6 @@ module Data.Geometry.Polygon
 
   , extremesLinear, cmpExtreme
 
-  , rotateLeft
-  , rotateRight
   , findRotateTo
 
   ) where

--- a/hgeometry/src/Data/Geometry/Transformation.hs
+++ b/hgeometry/src/Data/Geometry/Transformation.hs
@@ -54,7 +54,7 @@ type instance NumType (Transformation d r) = r
 -- | Compute the inverse transformation
 --
 -- >>> inverseOf $ translation (Vector2 (10.0) (5.0))
--- Transformation {_transformationMatrix = Matrix Vector3 [Vector3 [1.0,0.0,-10.0],Vector3 [0.0,1.0,-5.0],Vector3 [0.0,0.0,1.0]]}
+-- Transformation {_transformationMatrix = Matrix (Vector3 (Vector3 1.0 0.0 (-10.0)) (Vector3 0.0 1.0 (-5.0)) (Vector3 0.0 0.0 1.0))}
 inverseOf :: (Fractional r, Invertible (d + 1) r)
           => Transformation d r -> Transformation d r
 inverseOf = Transformation . inverse' . _transformationMatrix

--- a/hgeometry/src/Data/Geometry/Vector.hs
+++ b/hgeometry/src/Data/Geometry/Vector.hs
@@ -161,7 +161,7 @@ scalarMultiple' u v = g . F.foldr mappend mempty $ liftA2 f u v
 -- >>> Vector3 1 2 3 ^. xComponent
 -- 1
 -- >>> Vector2 1 2 & xComponent .~ 10
--- Vector2 [10,2]
+-- Vector2 10 2
 xComponent :: (1 <= d, Arity d) => Lens' (Vector d r) r
 xComponent = element (C :: C 0)
 {-# INLINABLE xComponent #-}
@@ -171,7 +171,7 @@ xComponent = element (C :: C 0)
 -- >>> Vector3 1 2 3 ^. yComponent
 -- 2
 -- >>> Vector2 1 2 & yComponent .~ 10
--- Vector2 [1,10]
+-- Vector2 1 10
 yComponent :: (2 <= d, Arity d) => Lens' (Vector d r) r
 yComponent = element (C :: C 1)
 {-# INLINABLE yComponent #-}
@@ -181,7 +181,7 @@ yComponent = element (C :: C 1)
 -- >>> Vector3 1 2 3 ^. zComponent
 -- 3
 -- >>> Vector3 1 2 3 & zComponent .~ 10
--- Vector3 [1,2,10]
+-- Vector3 1 2 10
 zComponent :: (3 <= d, Arity d) => Lens' (Vector d r) r
 zComponent = element (C :: C 2)
 {-# INLINABLE zComponent #-}


### PR DESCRIPTION
- Make the number of significant digits in RealNumber match the documentation. Now `RealNumber 2` will result in 2 significant digits rather than 3.
- Add parens around negative RealNumbers when necessary. This way, shown numbers can be copied into GHCi or Haskell code.
- Make `EndPoint` and `Range` instances of `Read1/Show1`.
- Add unit tests to verify all of this.