### PR TITLE
Improved robustness with limited precision numbers.

### DIFF
--- a/hgeometry-combinatorial/hgeometry-combinatorial.cabal
+++ b/hgeometry-combinatorial/hgeometry-combinatorial.cabal
@@ -54,6 +54,7 @@ library
 
                     -- * Numeric Data Types
                     Data.RealNumber.Rational
+                    Data.Double.Approximate
 
                     -- * Measurements
                     Data.Measured
@@ -147,6 +148,7 @@ library
               , aeson                   >= 1.0
               , yaml                    >= 0.8
               , text                    >= 1.1.1.0
+              , math-functions
 
               , mtl
               , template-haskell

--- a/hgeometry-combinatorial/src/Data/Double/Approximate.hs
+++ b/hgeometry-combinatorial/src/Data/Double/Approximate.hs
@@ -61,9 +61,9 @@ instance (KnownNat abs, KnownNat rel) => Eq (DoubleRelAbs abs rel) where
      abs d2 < m_epsilon * fromIntegral (natVal @abs Proxy))
 
 instance (KnownNat abs, KnownNat rel) => Ord (DoubleRelAbs abs rel) where
-  DoubleRelAbs d1 `compare` DoubleRelAbs d2
-    | within (fromIntegral (natVal @rel Proxy)) d1 d2 = EQ
-    | otherwise = d1 `compare` d2
+  lhs@(DoubleRelAbs d1) `compare` rhs@(DoubleRelAbs d2)
+    | lhs == rhs = EQ
+    | otherwise  = d1 `compare` d2
 
 instance Show (DoubleRelAbs abs rel) where
   showsPrec i (DoubleRelAbs d) = showsPrec i d

--- a/hgeometry-combinatorial/src/Data/Double/Approximate.hs
+++ b/hgeometry-combinatorial/src/Data/Double/Approximate.hs
@@ -1,0 +1,73 @@
+{-# LANGUAGE GADTs               #-}
+{-# LANGUAGE MagicHash           #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+-- | See: https://randomascii.wordpress.com/2012/02/25/comparing-floating-point-numbers-2012-edition/
+module Data.Double.Approximate
+  ( SafeDouble
+  , DoubleRelAbs(..)
+  ) where
+
+import Data.Proxy
+import GHC.TypeLits
+import Numeric.MathFunctions.Comparison
+import Numeric.MathFunctions.Constants
+import Text.Read
+
+-- | Relatively safe double floating-point type with a relative error
+--   margin of 10 ULPs and an absolute margin around zero of 10*epsilon.
+--
+--   Warning: All numbers within 10*epsilon of zero will be considered zero.
+--
+-- >>> m_epsilon * 10
+-- 2.220446049250313e-15
+--
+-- >>> realToFrac (m_epsilon * 10) == (0::SafeDouble)
+-- False
+--
+-- >>> realToFrac (m_epsilon * 9) == (0::SafeDouble)
+-- True
+--
+-- >>> 1e-20 == (5e-20 :: Double)
+-- False
+-- >>> 1e-20 == (5e-20 :: SafeDouble)
+-- True
+--
+-- 'pi' and 'sin' are approximations:
+-- >>> sin pi
+-- 1.2246467991473532e-16
+-- >>> sin pi == (0 :: Double)
+-- False
+-- >>> sin pi == (0 :: SafeDouble)
+-- True
+--
+type SafeDouble = DoubleRelAbs 10 10
+
+-- | Custom double floating-point type with a relative error margin of
+--   'rel' number of ULPs and an absolute error margin of 'abs' times
+--   epsilon.
+--
+--   The relative error margin is the primary tool for good numerical
+--   robustness and can relatively safely be set to a high number such
+--   as 100. The absolute error margin is a last ditch attempt at fixing
+--   broken algorithms and dramatically limits the resolution around zero.
+--   If possible, use a low absolute error margin.
+newtype DoubleRelAbs (abs :: Nat) (rel :: Nat) = DoubleRelAbs Double
+  deriving (Num, Enum, Floating, Fractional, Real, RealFloat, RealFrac)
+
+instance (KnownNat abs, KnownNat rel) => Eq (DoubleRelAbs abs rel) where
+  DoubleRelAbs d1 == DoubleRelAbs d2 =
+    within (fromIntegral (natVal @rel Proxy)) d1 d2 ||
+    (abs d1 < m_epsilon * fromIntegral (natVal @abs Proxy) &&
+     abs d2 < m_epsilon * fromIntegral (natVal @abs Proxy))
+
+instance (KnownNat abs, KnownNat rel) => Ord (DoubleRelAbs abs rel) where
+  DoubleRelAbs d1 `compare` DoubleRelAbs d2
+    | within (fromIntegral (natVal @rel Proxy)) d1 d2 = EQ
+    | otherwise = d1 `compare` d2
+
+instance Show (DoubleRelAbs abs rel) where
+  showsPrec i (DoubleRelAbs d) = showsPrec i d
+
+instance Read (DoubleRelAbs abs rel) where
+  readPrec = DoubleRelAbs <$> readPrec
+

--- a/hgeometry-test/hgeometry-test.cabal
+++ b/hgeometry-test/hgeometry-test.cabal
@@ -80,6 +80,7 @@ test-suite hspec
                  Data.Geometry.PolygonSpec
                  Data.Geometry.LineSegmentSpec
                  Data.Geometry.PointSpec
+                 Data.Geometry.VectorSpec
                  Data.Geometry.Polygon.Convex.ConvexSpec
                  Data.Geometry.Polygon.Convex.LowerTangentSpec
                  Data.Geometry.Polygon.PickPointSpec

--- a/hgeometry-test/src/Data/Geometry/PointSpec.hs
+++ b/hgeometry-test/src/Data/Geometry/PointSpec.hs
@@ -152,12 +152,3 @@ spec = do
     property $ qcReadShow1 @(Point 3) Proxy
   specify "Read/Show properties for Point4" $
     property $ qcReadShow1 @(Point 4) Proxy
-
-  specify "Read/Show properties for Vector1" $
-    property $ qcReadShow1 @(Vector 1) Proxy
-  specify "Read/Show properties for Vector2" $
-    property $ qcReadShow1 @(Vector 2) Proxy
-  specify "Read/Show properties for Vector3" $
-    property $ qcReadShow1 @(Vector 3) Proxy
-  specify "Read/Show properties for Vector4" $
-    property $ qcReadShow1 @(Vector 4) Proxy

--- a/hgeometry-test/src/Data/Geometry/PointSpec.hs
+++ b/hgeometry-test/src/Data/Geometry/PointSpec.hs
@@ -10,8 +10,18 @@ import           Test.Hspec
 import           Test.QuickCheck
 import           Test.QuickCheck.Instances     ()
 import           Test.Util
+import Data.Double.Approximate (SafeDouble, DoubleRelAbs(..))
+import Data.Coerce
 
 --------------------------------------------------------------------------------
+
+{-# NOINLINE double1 #-}
+{-# NOINLINE double2 #-}
+{-# NOINLINE double3 #-}
+double1, double2 :: Double
+double1 = 1e100
+double2 = 1.1
+double3 = 1.2
 
 spec :: Spec
 spec = do
@@ -34,6 +44,27 @@ spec = do
       property $ \(c :: Point 2 Int) (p :: Point 2 Int) (q :: Point 2 Int) ->
         (p /= c && q /= c) ==>
         cwCmpAroundWithDist c p q == cwCmpAroundByQuadrantWithDist (ext c) (ext p) (ext q)
+
+  describe "numerical robustness" $ do
+    it "1e0" $
+      ccw (Point2 0 0) (Point2 1 1) (Point2 2 (2::Double)) `shouldBe` CoLinear
+
+    -- 'ccw' is doing this calculation:
+    -- 1.2 * 1e100 * 1.1 -
+    -- 1.1 * 1e100 * 1.2 =
+    -- 0
+    -- With infinite precision, everything should cancel out and the result is exactly 0.
+    -- But Double doesn't have infinite precision so we end up with an error of 1 ULP
+    -- for 1e100 which is a huge number 1.942668892225729e84. Obviously far greater than 0.
+    -- We can get around this problem by using SafeDouble which considers doubles to be
+    -- equal if they are within 10 ULPs.
+    let doubleP1 = Point2 double3 double2
+        doubleP2 = Point2 (double1*double3) (double1*double2)
+    it "1e100" $
+      ccw (Point2 0 0) doubleP1 doubleP2 `shouldNotBe` CoLinear
+    it "1e100" $
+      ccw (Point2 0 0) (coerce <$> doubleP1) (coerce <$> doubleP2 :: Point 2 SafeDouble)
+        `shouldBe` CoLinear
 
   describe "Sort Arround a Point test" $ do
     it "Sort around origin" $

--- a/hgeometry-test/src/Data/Geometry/PolygonSpec.hs
+++ b/hgeometry-test/src/Data/Geometry/PolygonSpec.hs
@@ -251,12 +251,11 @@ polygon = fromPoints $ map ext
   , Point2 5579688.373487147 2252038.6420285213
   ]
 
+
 insidePoint, outsidePoint :: Fractional r => Point 2 r
 insidePoint  = Point2 5565974.538888888 2273030.9266712796
 outsidePoint = Point2 5814191.399840455 2393283.2821864313
 
--- FIXME: 'inPolygon' tries to find all intersections instead of just counting them.
---        This leads to numerical instability.
 numericalSpec :: Spec
 numericalSpec =
   describe "insidePolygon" $ do

--- a/hgeometry-test/src/Data/Geometry/PolygonSpec.hs
+++ b/hgeometry-test/src/Data/Geometry/PolygonSpec.hs
@@ -259,7 +259,7 @@ outsidePoint = Point2 5814191.399840455 2393283.2821864313
 --        This leads to numerical instability.
 numericalSpec :: Spec
 numericalSpec =
-  xdescribe "insidePolygon" $ do
+  describe "insidePolygon" $ do
     specify "baseline check" $ do
       ((insidePoint::Point 2 Rational) `inPolygon` polygon) `shouldBe` Inside
       ((outsidePoint::Point 2 Rational) `inPolygon` polygon) `shouldBe` Outside

--- a/hgeometry-test/src/Data/Geometry/PolygonSpec.hs
+++ b/hgeometry-test/src/Data/Geometry/PolygonSpec.hs
@@ -3,16 +3,18 @@ module Data.Geometry.PolygonSpec (spec) where
 
 import           Algorithms.Geometry.LineSegmentIntersection
 import           Control.Lens                                (over, view, (^.), (^..))
-import           Control.Monad.Random (Random, evalRand, mkStdGen)
+import           Control.Monad.Random                        (Random, evalRand, mkStdGen)
 import qualified Data.ByteString                             as BS
 import           Data.Coerce
+import           Data.Double.Approximate
 import           Data.Ext
 import qualified Data.Foldable                               as F
 import           Data.Geometry
 import           Data.Geometry.Boundary
 import           Data.Geometry.Ipe
-import           Data.Geometry.Triangle
+import           Data.Geometry.Polygon
 import           Data.Geometry.Polygon.Monotone
+import           Data.Geometry.Triangle
 import           Data.Ord
 import           Data.Proxy
 import           Data.Ratio
@@ -163,6 +165,7 @@ spec = do
   it "is monotone" $
     property $ forAll genMonotone $ \(dir, mono :: SimplePolygon () R) ->
       isMonotone dir mono
+  numericalSpec
 
 testCases    :: FilePath -> Spec
 testCases fp = runIO (readInputFromFile =<< getDataFileName fp) >>= \case
@@ -234,3 +237,35 @@ readInputFromFile fp = fmap f <$> readSinglePageFile fp
 
 
 -- main = readInputFromFile "tests/Data/Geometry/pointInPolygon.ipe"
+
+
+----------------------------------
+-- Numerical Robustness
+
+-- Test case found by Kamil Figiela @kfigiela.
+polygon :: (Eq r, Fractional r) => SimplePolygon () r
+polygon = fromPoints $ map ext
+  [ Point2 5584390.945938013 2284567.4635945037
+  , Point2 5562410.061516319 2285869.7979417136
+  , Point2 5563196.65161862  2250738.663576637
+  , Point2 5579688.373487147 2252038.6420285213
+  ]
+
+insidePoint, outsidePoint :: Fractional r => Point 2 r
+insidePoint  = Point2 5565974.538888888 2273030.9266712796
+outsidePoint = Point2 5814191.399840455 2393283.2821864313
+
+-- FIXME: 'inPolygon' tries to find all intersections instead of just counting them.
+--        This leads to numerical instability.
+numericalSpec :: Spec
+numericalSpec =
+  xdescribe "insidePolygon" $ do
+    specify "baseline check" $ do
+      ((insidePoint::Point 2 Rational) `inPolygon` polygon) `shouldBe` Inside
+      ((outsidePoint::Point 2 Rational) `inPolygon` polygon) `shouldBe` Outside
+    it "describes possible regression" $ do
+      ((insidePoint::Point 2 Double) `inPolygon` polygon) `shouldBe` Inside
+      ((outsidePoint::Point 2 Double) `inPolygon` polygon) `shouldBe` Outside
+    it "describes possible regression" $ do
+      ((insidePoint::Point 2 SafeDouble) `inPolygon` polygon) `shouldBe` Inside
+      ((outsidePoint::Point 2 SafeDouble) `inPolygon` polygon) `shouldBe` Outside

--- a/hgeometry-test/src/Data/Geometry/SubLineSpec.hs
+++ b/hgeometry-test/src/Data/Geometry/SubLineSpec.hs
@@ -24,6 +24,13 @@ spec = do
       ((Point2 (-1) (-1 :: Rational)) `onSubLine2`
        (seg^._SubLine))
     `shouldBe` False
+  it "open intersection " $ do
+      ((Point2 1 1) `onSubLine2` (seg2^._SubLine))
+        `shouldBe` False
+      ((Point2 5 5) `onSubLine2` (seg2^._SubLine))
+        `shouldBe` False
+      ((Point2 2 2) `onSubLine2` (seg2^._SubLine))
+        `shouldBe` True
 
   it "Intersection test" $ do
     let mySeg :: LineSegment 2 () Rational
@@ -49,6 +56,8 @@ mkSL s = s^._SubLine.re _unBounded
 seg :: LineSegment 2 () Rational
 seg = ClosedLineSegment (ext (Point2 1 1)) (ext (Point2 5 5))
 
+seg2 :: LineSegment 2 () Rational
+seg2 = OpenLineSegment (ext (Point2 1 1)) (ext (Point2 5 5))
 
 
 -- | Original def of onSubline

--- a/hgeometry-test/src/Data/Geometry/VectorSpec.hs
+++ b/hgeometry-test/src/Data/Geometry/VectorSpec.hs
@@ -1,0 +1,32 @@
+module Data.Geometry.VectorSpec (spec) where
+
+import           Data.Geometry.Vector
+import           Data.Proxy
+import           Test.Hspec
+import           Test.QuickCheck
+import           Test.QuickCheck.Instances     ()
+import           Test.Util
+import Data.Double.Approximate (SafeDouble)
+
+--------------------------------------------------------------------------------
+
+spec :: Spec
+spec = do
+  describe "numerical robustness" $ do
+    it "1e0" $
+      isScalarMultipleOf (Vector2 1 10) (Vector2 10 (10*10::Double)) `shouldBe` True
+    -- With sufficiently large numbers, isScalarMultipleOf fails for Doubles.
+    it "1e10 (fail)" $
+      isScalarMultipleOf (Vector2 1 10) (Vector2 1e10 (1e10*10::Double)) `shouldBe` False
+    -- SafeDouble should work better.
+    it "1e10 (pass)" $
+      isScalarMultipleOf (Vector2 1 10) (Vector2 1e10 (1e10*10::SafeDouble)) `shouldBe` True
+
+  specify "Read/Show properties for Vector1" $
+    property $ qcReadShow1 @(Vector 1) Proxy
+  specify "Read/Show properties for Vector2" $
+    property $ qcReadShow1 @(Vector 2) Proxy
+  specify "Read/Show properties for Vector3" $
+    property $ qcReadShow1 @(Vector 3) Proxy
+  specify "Read/Show properties for Vector4" $
+    property $ qcReadShow1 @(Vector 4) Proxy

--- a/hgeometry/src/Data/Geometry/HalfLine.hs
+++ b/hgeometry/src/Data/Geometry/HalfLine.hs
@@ -1,6 +1,6 @@
-{-# LANGUAGE TemplateHaskell  #-}
+{-# LANGUAGE DeriveAnyClass       #-}
+{-# LANGUAGE TemplateHaskell      #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE DeriveAnyClass #-}
 --------------------------------------------------------------------------------
 -- |
 -- Module      :  Data.Geometry.HalfLine
@@ -14,7 +14,7 @@ module Data.Geometry.HalfLine where
 import           Control.DeepSeq
 import           Control.Lens
 import           Data.Ext
-import qualified Data.Foldable as F
+import qualified Data.Foldable                as F
 import           Data.Geometry.Interval
 import           Data.Geometry.Line
 import           Data.Geometry.LineSegment
@@ -23,9 +23,10 @@ import           Data.Geometry.Properties
 import           Data.Geometry.SubLine
 import           Data.Geometry.Transformation
 import           Data.Geometry.Vector
-import qualified Data.Traversable as T
+import qualified Data.Traversable             as T
 import           Data.UnBounded
-import           GHC.Generics (Generic)
+import qualified Data.Vector.Fixed            as FV
+import           GHC.Generics                 (Generic)
 import           GHC.TypeLits
 
 --------------------------------------------------------------------------------
@@ -47,6 +48,14 @@ deriving instance Arity d           => T.Traversable (HalfLine d)
 type instance Dimension (HalfLine d r) = d
 type instance NumType   (HalfLine d r) = r
 
+
+instance {-# OVERLAPPING #-} (Eq r, Fractional r) => Eq (HalfLine 2 r) where
+  (HalfLine p u) == (HalfLine q v) =
+      p == q && -- Same starting point.
+      isCoLinear p (Point u) (Point v) && -- Directions are on the same line.
+      sameSigns -- Directions point in the same quadrant.
+    where
+      sameSigns = F.and $ FV.zipWith (\a b -> signum a==signum b) u v
 
 instance (Eq r, Fractional r, Arity d) => Eq (HalfLine d r) where
   (HalfLine p u) == (HalfLine q v) = let lam = scalarMultiple u v

--- a/hgeometry/src/Data/Geometry/Line/Internal.hs
+++ b/hgeometry/src/Data/Geometry/Line/Internal.hs
@@ -145,15 +145,24 @@ toOffset              :: (Eq r, Fractional r, Arity d) => Point d r -> Line d r 
 toOffset p (Line q v) = scalarMultiple (p .-. q) v
 
 
--- | Given point p *on* a line (Line q v), Get the scalar lambda s.t.
--- p = q + lambda v. (So this is an unsafe version of 'toOffset')
+-- | Given point p near a line (Line q v), get the scalar lambda s.t.
+-- the distance between 'p' and 'q + lambda v' is minimized.
 --
--- pre: the input point p lies on the line l.
+-- >>> toOffset' (Point2 1 1) (lineThrough origin $ Point2 10 10)
+-- 0.1
+--
+-- >>> toOffset' (Point2 5 5) (lineThrough origin $ Point2 10 10)
+-- 0.5
+--
+-- \<6,4\> is not on the line but we can still point closest to it.
+-- >>> toOffset' (Point2 6 4) (lineThrough origin $ Point2 10 10)
+-- 0.5
 toOffset'             :: (Eq r, Fractional r, Arity d) => Point d r -> Line d r -> r
-toOffset' p = fromJust' . toOffset p
-  where
-    fromJust' (Just x) = x
-    fromJust' _        = error "toOffset: Nothing"
+toOffset' p (Line q v) = dot (p .-. q) v / quadrance v
+-- toOffset' p = fromJust' . toOffset p
+--   where
+--     fromJust' (Just x) = x
+--     fromJust' _        = error "toOffset: Nothing"
 
 
 -- | The intersection of two lines is either: NoIntersection, a point or a line.

--- a/hgeometry/src/Data/Geometry/Point.hs
+++ b/hgeometry/src/Data/Geometry/Point.hs
@@ -19,7 +19,7 @@ module Data.Geometry.Point( Point(.., Point1, Point2, Point3)
 
                           , PointFunctor(..)
 
-                          , CCW, ccw, ccw'
+                          , CCW, ccw, ccw', isCoLinear
                           , pattern CCW, pattern CW, pattern CoLinear
 
                           , ccwCmpAround, ccwCmpAround'

--- a/hgeometry/src/Data/Geometry/Point/Orientation/Degenerate.hs
+++ b/hgeometry/src/Data/Geometry/Point/Orientation/Degenerate.hs
@@ -50,7 +50,9 @@ instance Show CCW where
 
 -- | Given three points p q and r determine the orientation when going from p to r via q.
 ccw :: (Ord r, Num r) => Point 2 r -> Point 2 r -> Point 2 r -> CCW
-ccw p q r = CCWWrap $ z `compare` 0
+ccw p q r = CCWWrap $ (ux * vy) `compare` (uy * vx)
+-- ccw p q r = CCWWrap $ z `compare` 0 -- Comparing against 0 is bad for numerical robustness.
+                                       -- I've added a testcase that fails if comparing against 0.
             -- case z `compare` 0 of
             --   LT -> CW
             --   GT -> CCW
@@ -58,7 +60,7 @@ ccw p q r = CCWWrap $ z `compare` 0
      where
        Vector2 ux uy = q .-. p
        Vector2 vx vy = r .-. p
-       z             = ux * vy - uy * vx
+       _z             = ux * vy - uy * vx
 
 -- | Given three points p q and r determine the orientation when going from p to r via q.
 ccw' :: (Ord r, Num r) => Point 2 r :+ a -> Point 2 r :+ b -> Point 2 r :+ c -> CCW

--- a/hgeometry/src/Data/Geometry/Point/Orientation/Degenerate.hs
+++ b/hgeometry/src/Data/Geometry/Point/Orientation/Degenerate.hs
@@ -24,6 +24,9 @@ import qualified Data.List as L
 
 --------------------------------------------------------------------------------
 
+-- $setup
+-- >>> import Data.Double.Approximate
+
 -- | Data type for expressing the orientation of three points, with
 -- the option of allowing Colinearities.
 newtype CCW = CCWWrap Ordering deriving Eq
@@ -49,6 +52,18 @@ instance Show CCW where
 
 
 -- | Given three points p q and r determine the orientation when going from p to r via q.
+--
+-- Be vary of numerical instability:
+-- >>> ccw (Point2 0 0.3) (Point2 1 0.6) (Point2 2 (0.9::Double))
+-- CCW
+--
+-- >>> ccw (Point2 0 0.3) (Point2 1 0.6) (Point2 2 (0.9::Rational))
+-- CoLinear
+--
+-- If you can't use 'Rational', try 'SafeDouble' instead of 'Double':
+-- >>> ccw (Point2 0 0.3) (Point2 1 0.6) (Point2 2 (0.9::SafeDouble))
+-- CoLinear
+--
 ccw :: (Ord r, Num r) => Point 2 r -> Point 2 r -> Point 2 r -> CCW
 ccw p q r = CCWWrap $ (ux * vy) `compare` (uy * vx)
 -- ccw p q r = CCWWrap $ z `compare` 0 -- Comparing against 0 is bad for numerical robustness.

--- a/hgeometry/src/Data/Geometry/Point/Orientation/Degenerate.hs
+++ b/hgeometry/src/Data/Geometry/Point/Orientation/Degenerate.hs
@@ -4,6 +4,8 @@ module Data.Geometry.Point.Orientation.Degenerate(
 
   , ccw, ccw'
 
+  , isCoLinear
+
   , sortAround, sortAround'
 
   , ccwCmpAroundWith, ccwCmpAroundWith'
@@ -76,6 +78,15 @@ ccw p q r = CCWWrap $ (ux * vy) `compare` (uy * vx)
        Vector2 ux uy = q .-. p
        Vector2 vx vy = r .-. p
        _z             = ux * vy - uy * vx
+
+-- | Given three points p q and r determine if the line from p to r via q is straight/colinear.
+--
+-- This is identical to `ccw p q r == CoLinear` but doesn't have the `Ord` constraint.
+isCoLinear :: (Eq r, Num r) => Point 2 r -> Point 2 r -> Point 2 r -> Bool
+isCoLinear p q r = (ux * vy) == (uy * vx)
+     where
+       Vector2 ux uy = q .-. p
+       Vector2 vx vy = r .-. p
 
 -- | Given three points p q and r determine the orientation when going from p to r via q.
 ccw' :: (Ord r, Num r) => Point 2 r :+ a -> Point 2 r :+ b -> Point 2 r :+ c -> CCW

--- a/hgeometry/src/Data/Geometry/Point/Orientation/Degenerate.hs
+++ b/hgeometry/src/Data/Geometry/Point/Orientation/Degenerate.hs
@@ -67,7 +67,7 @@ instance Show CCW where
 -- CoLinear
 --
 ccw :: (Ord r, Num r) => Point 2 r -> Point 2 r -> Point 2 r -> CCW
-ccw p q r = CCWWrap $ (ux * vy) `compare` (uy * vx)
+ccw p q r = CCWWrap $ lhs `compare` rhs
 -- ccw p q r = CCWWrap $ z `compare` 0 -- Comparing against 0 is bad for numerical robustness.
                                        -- I've added a testcase that fails if comparing against 0.
             -- case z `compare` 0 of
@@ -75,9 +75,16 @@ ccw p q r = CCWWrap $ (ux * vy) `compare` (uy * vx)
             --   GT -> CCW
             --   EQ -> CoLinear
      where
-       Vector2 ux uy = q .-. p
-       Vector2 vx vy = r .-. p
-       _z             = ux * vy - uy * vx
+       Point2 px py = p
+       Point2 qx qy = q
+       Point2 rx ry = r
+       -- Expending the equations avoids premature rounding. This is essential for numerical
+       -- robustness.
+       lhs = qx*ry-qx*py-px*ry+px*py -- (qx-px) * (ry-py)
+       rhs = qy*rx-qy*px-py*rx+py*px -- (qy-py) * (rx-px)
+      --  Vector2 ux uy = q .-. p
+      --  Vector2 vx vy = r .-. p
+      --  _z             = ux * vy - uy * vx
 
 -- | Given three points p q and r determine if the line from p to r via q is straight/colinear.
 --

--- a/hgeometry/src/Data/Geometry/SubLine.hs
+++ b/hgeometry/src/Data/Geometry/SubLine.hs
@@ -93,7 +93,12 @@ onSubLine p (SubLine l r) = case toOffset p l of
 onSubLineUB                   :: (Ord r, Fractional r)
                               => Point 2 r -> SubLine 2 p (UnBounded r) r -> Bool
 p `onSubLineUB` (SubLine l r) =
-  p `onLine2` l && Val (toOffset' p l) `inInterval` r
+  p `onLine2` l &&
+  Val (toOffset' p l) `inInterval` r
+
+inSubLineIntervalUB                   :: (Ord r, Fractional r)
+                              => Point 2 r -> SubLine 2 p (UnBounded r) r -> Bool
+p `inSubLineIntervalUB` (SubLine l r) = Val (toOffset' p l) `inInterval` r
 
 -- | given point p, and a Subline l r such that p lies on line l, test if it
 -- lies on the subline, i.e. in the interval r
@@ -150,7 +155,7 @@ instance (Ord r, Fractional r) =>
 
   sl@(SubLine l r) `intersect` sm@(SubLine m _) = match (l `intersect` m) $
          H (\NoIntersection -> coRec NoIntersection)
-      :& H (\p@(Point _)    -> if onSubLine2UB p sl && onSubLine2UB p sm
+      :& H (\p@(Point _)    -> if inSubLineIntervalUB p sl && inSubLineIntervalUB p sm
                                  then coRec p
                                  else coRec NoIntersection)
       :& H (\_              -> match (r `intersect` s'') $

--- a/hgeometry/src/Data/Geometry/SubLine.hs
+++ b/hgeometry/src/Data/Geometry/SubLine.hs
@@ -92,9 +92,8 @@ onSubLine p (SubLine l r) = case toOffset p l of
 -- lies on the subline, i.e. in the interval r
 onSubLineUB                   :: (Ord r, Fractional r)
                               => Point 2 r -> SubLine 2 p (UnBounded r) r -> Bool
-p `onSubLineUB` (SubLine l r) = case toOffset p l of
-                                  Nothing -> False
-                                  Just x  -> Val x `inInterval` r
+p `onSubLineUB` (SubLine l r) =
+  p `onLine2` l && Val (toOffset' p l) `inInterval` r
 
 -- | given point p, and a Subline l r such that p lies on line l, test if it
 -- lies on the subline, i.e. in the interval r

--- a/hgeometry/src/Data/Geometry/SubLine.hs
+++ b/hgeometry/src/Data/Geometry/SubLine.hs
@@ -9,7 +9,22 @@
 -- SubLine; a part of a line
 --
 --------------------------------------------------------------------------------
-module Data.Geometry.SubLine where
+module Data.Geometry.SubLine
+  ( SubLine(..)
+  , line
+  , subRange
+  , fixEndPoints
+  , dropExtra
+  , _unBounded
+  , toUnbounded
+  , fromUnbounded
+  , onSubLine
+  , onSubLineUB
+  , onSubLine2
+  , onSubLine2UB
+  , getEndPointsUnBounded
+  , fromLine
+  ) where
 
 import           Control.Lens
 import           Data.Bifunctor

--- a/hgeometry/src/Data/Geometry/Vector.hs
+++ b/hgeometry/src/Data/Geometry/Vector.hs
@@ -86,7 +86,7 @@ isScalarMultipleOf       :: (Eq r, Fractional r, Arity d)
                          => Vector d r -> Vector d r -> Bool
 u `isScalarMultipleOf` v = let d = u `dot` v
                                num = quadrance u * quadrance v
-                           in num == 0 || 1 == d*d / num
+                           in num == 0 || num == d*d
 -- u `isScalarMultipleOf` v = isJust $ scalarMultiple u v
 {-# SPECIALIZE
     isScalarMultipleOf :: (Eq r, Fractional r) => Vector 2 r -> Vector 2 r -> Bool  #-}


### PR DESCRIPTION
 - [x] Add variant of Double which supports both relative and absolute error margins.
 - [x] Improve the numerical robustness of `ccw`
 - [x] Change `toOffset'` such that it never throws exceptions.
 - [x] Change `onSubLineUB` to use the more robust `onLine2`.
 - [x] `Eq (HalfLine 2 r)` doesn't use `scalarMultiple`.