### PR TITLE
Yet more haddock documentation.

### DIFF
--- a/hgeometry-combinatorial/src/Algorithms/FloydWarshall.hs
+++ b/hgeometry-combinatorial/src/Algorithms/FloydWarshall.hs
@@ -40,9 +40,11 @@ floydWarshall n graph = do
     put idx e = V.unsafeWrite graph (mkIndex n idx) e
     eps = 1e-10 -- When two paths are nearly the same length, pick the one with the fewest segments.
 
+-- | Compute the index of an element in a given range.
 mkIndex :: Num a => a -> (a, a) -> a
 mkIndex n (i,j) = i*n+j
 
+-- | Construct a weighted graph from \(n\) vertices, a max bound, and a list of weighted edges.
 mkGraph :: (Unbox a, Num a) => Int -> a -> [(Int,Int,a)] -> ST s (MVector s (a, Int))
 mkGraph n maxValue edges = do
   graph <- V.replicate (n*n) (maxValue, maxBound)

--- a/hgeometry-combinatorial/src/Control/CanAquire.hs
+++ b/hgeometry-combinatorial/src/Control/CanAquire.hs
@@ -37,7 +37,7 @@ runAcquire alg pts = reify v $ \px -> alg (coerceTS px ts)
       -- Ideally this would just be a coerce. But GHC doesn't want to do that.
 
 class HasIndex i Int => CanAquire i a where
-  -- | A value of type i can obtain something of type 'a'
+  -- | A value of type i can obtain something of type @\'a\'@
   aquire  :: i -> a
 
 class HasIndex t i | t -> i where

--- a/hgeometry-combinatorial/src/Data/BinaryTree.hs
+++ b/hgeometry-combinatorial/src/Data/BinaryTree.hs
@@ -119,11 +119,12 @@ zipExactWith _ _ _            _               =
 --------------------------------------------------------------------------------
 -- * Converting into a Data.Tree
 
+-- | \( O(n) \) Convert binary tree to a rose tree, aka 'Tree.Tree'.
 toRoseTree              :: BinLeafTree v a -> Tree.Tree (TreeNode v a)
 toRoseTree (Leaf x)     = Tree.Node (LeafNode x) []
 toRoseTree (Node l v r) = Tree.Node (InternalNode v) (map toRoseTree [l,r])
 
-
+-- | 2-dimensional ASCII drawing of a tree.
 drawTree :: (Show v, Show a) => BinLeafTree v a -> String
 drawTree = Tree.drawTree . fmap show . toRoseTree
 

--- a/hgeometry-combinatorial/src/Data/Double/Approximate.hs
+++ b/hgeometry-combinatorial/src/Data/Double/Approximate.hs
@@ -14,9 +14,12 @@ import Numeric.MathFunctions.Constants
 import Text.Read
 
 -- | Relatively safe double floating-point type with a relative error
---   margin of 10 ULPs and an absolute margin around zero of 10*epsilon.
+--   margin of 10 <https://en.wikipedia.org/wiki/Unit_in_the_last_place ULPs>
+--   and an absolute margin around zero of
+--   @10*<https://en.wikipedia.org/wiki/Machine_epsilon epsilon>@.
 --
---   Warning: All numbers within 10*epsilon of zero will be considered zero.
+--   Warning: All numbers within
+--   @10*<https://en.wikipedia.org/wiki/Machine_epsilon epsilon>@ of zero will be considered zero.
 --
 -- >>> m_epsilon * 10
 -- 2.220446049250313e-15
@@ -33,18 +36,23 @@ import Text.Read
 -- True
 --
 -- 'pi' and 'sin' are approximations:
+--
 -- >>> sin pi
 -- 1.2246467991473532e-16
+--
 -- >>> sin pi == (0 :: Double)
 -- False
+--
 -- >>> sin pi == (0 :: SafeDouble)
 -- True
 --
 type SafeDouble = DoubleRelAbs 10 10
 
 -- | Custom double floating-point type with a relative error margin of
---   'rel' number of ULPs and an absolute error margin of 'abs' times
---   epsilon.
+--   @rel@ number of
+--   <https://en.wikipedia.org/wiki/Unit_in_the_last_place ULPs> and an
+--   absolute error margin of @abs@ times
+--   <https://en.wikipedia.org/wiki/Machine_epsilon epsilon>.
 --
 --   The relative error margin is the primary tool for good numerical
 --   robustness and can relatively safely be set to a high number such

--- a/hgeometry-combinatorial/src/Data/DynamicOrd.hs
+++ b/hgeometry-combinatorial/src/Data/DynamicOrd.hs
@@ -17,7 +17,7 @@ import Unsafe.Coerce
 -- Implementation from
 -- https://www.schoolofhaskell.com/user/thoughtpolice/using-reflection
 
--- | Values of type 'a' in our dynamically constructed 'Ord' instance
+-- | Values of type '@a@' in our dynamically constructed 'Ord' instance
 newtype O (s :: *) (a :: *) = O { runO :: a } deriving (Show)
 
 -- | An Ord Dictionary
@@ -44,35 +44,35 @@ withOrd cmp v = reify (OrdDict cmp) (runO . asProxyOf v)
 -- * Introducing and removing the dynamic order type
 -- Note that all of these may be unsafe if used incorrectly
 
--- | Lifts a container f whose values (of type a) depend on 's' into a
--- more general computation in that produces a 'f a' (depending on s).
+-- | Lifts a container f whose values (of type a) depend on '@s@' into a
+-- more general computation in that produces a '@f a@' (depending on s).
 --
 -- running time: \(O(1)\)
 extractOrd1 :: f (O s a) -> O s (f a)
 extractOrd1 = unsafeCoerce
 
 
--- | Introduce dynamic order in a container 'f'.
+-- | Introduce dynamic order in a container '@f@'.
 --
 -- running time: \(O(1)\)
 introOrd1 :: f a -> f (O s a)
 introOrd1 = unsafeCoerce
 
--- | Lifts a function that works on a container 'f' of
+-- | Lifts a function that works on a container '@f@' of
 -- orderable-things into one that works on dynamically ordered ones.
 liftOrd1   :: (f (O s a) -> f (O s a))
            -> f a -> O s (f a)
 liftOrd1 f = extractOrd1 . f . introOrd1
 
 
--- | Lifts a container f whose keys (of type k) depend on 's' into a
--- more general computation in that produces a 'f k v' (depending on s).
+-- | Lifts a container f whose keys (of type k) depend on '@s@' into a
+-- more general computation in that produces a @`f k v`@ (depending on s).
 --
 -- running time: \(O(1)\)
 extractOrd2 :: f (O s k) v -> O s (f k v)
 extractOrd2 = unsafeCoerce
 
--- | Introduce dynamic order in a container 'f' that has keys of type
+-- | Introduce dynamic order in a container '@f@' that has keys of type
 -- k.
 --
 -- running time: \(O(1)\)

--- a/hgeometry-combinatorial/src/Data/IndexedDoublyLinkedList.hs
+++ b/hgeometry-combinatorial/src/Data/IndexedDoublyLinkedList.hs
@@ -33,6 +33,7 @@ import qualified Data.Vector.Mutable as MV
 
 --------------------------------------------------------------------------------
 
+-- | Cell indices. Must be non-negative.
 type Index = Int
 
 -- TODO: Switch to unobxed sums for these!
@@ -42,6 +43,7 @@ data Cell = Cell { prev :: Maybe Index
                  , next :: Maybe Index
                  } deriving (Show,Eq)
 
+-- | Empty cell with no next or prev cells.
 emptyCell :: Cell
 emptyCell = Cell Nothing Nothing
 
@@ -128,6 +130,7 @@ toListFromK i k = (i :|) <$> replicateM k getNext i
 toListFromR :: Index -> DLListMonad s b (NonEmpty Index)
 toListFromR i = (i :|) <$> iterateM getPrev i
 
+-- | Takes the current element and its k prev's
 toListFromRK     :: Index -> Int -> DLListMonad s b (NonEmpty Index)
 toListFromRK i k = (i :|) <$> replicateM k getPrev i
 

--- a/hgeometry-combinatorial/src/Data/IndexedDoublyLinkedList/Bare.hs
+++ b/hgeometry-combinatorial/src/Data/IndexedDoublyLinkedList/Bare.hs
@@ -34,6 +34,7 @@ import qualified Data.Vector.Mutable as MV
 
 --------------------------------------------------------------------------------
 
+-- | Cell indices. Must be non-negative.
 type Index = Int
 
 -- | Cells in the Linked List
@@ -41,6 +42,7 @@ data Cell = Cell { prev :: !(Maybe Index)
                  , next :: !(Maybe Index)
                  } deriving (Show,Eq)
 
+-- | Empty cell with no next or prev cells.
 emptyCell :: Cell
 emptyCell = Cell Nothing Nothing
 
@@ -116,6 +118,7 @@ toListFromK i k = (i :|) <$> replicateM k getNext i
 toListFromR :: Index -> IDLListMonad s (NonEmpty Index)
 toListFromR i = (i :|) <$> iterateM getPrev i
 
+-- | Takes the current element and its k prev's
 toListFromRK     :: Index -> Int -> IDLListMonad s (NonEmpty Index)
 toListFromRK i k = (i :|) <$> replicateM k getPrev i
 

--- a/hgeometry-combinatorial/src/Data/Intersection.hs
+++ b/hgeometry-combinatorial/src/Data/Intersection.hs
@@ -35,6 +35,7 @@ type family IntersectionOf g h :: [*]
 coRec :: (a ∈ as) => a -> CoRec Identity as
 coRec = CoRec . Identity
 
+-- | Class relationship between intersectable geometric objects.
 class IsIntersectableWith g h where
   intersect :: g -> h -> Intersection g h
 

--- a/hgeometry-combinatorial/src/Data/LSeq.hs
+++ b/hgeometry-combinatorial/src/Data/LSeq.hs
@@ -216,13 +216,13 @@ drop i = wrapUnsafe (S.drop i)
 -- | \( O(n \log n) \).  A generalization of 'unstableSort', 'unstableSortBy'
 -- takes an arbitrary comparator and sorts the specified sequence.
 -- The sort is not stable.  This algorithm is frequently faster and
--- uses less memory than 'sortBy'.
+-- uses less memory than 'Data.Sequence.sortBy'.
 unstableSortBy   :: (a -> a -> Ordering) -> LSeq n a -> LSeq n a
 unstableSortBy f = wrapUnsafe (S.unstableSortBy f)
 
--- | \( O(n \log n) \).  'unstableSort' sorts the specified 'Seq' by
+-- | \( O(n \log n) \).  'unstableSort' sorts the specified 'LSeq' by
 -- the natural ordering of its elements, but the sort is not stable.
--- This algorithm is frequently faster and uses less memory than 'sort'.
+-- This algorithm is frequently faster and uses less memory than 'Data.Sequence.sort'.
 unstableSort :: Ord a => LSeq n a -> LSeq n a
 unstableSort = wrapUnsafe S.unstableSort
 

--- a/hgeometry-combinatorial/src/Data/List/Alternating.hs
+++ b/hgeometry-combinatorial/src/Data/List/Alternating.hs
@@ -22,7 +22,7 @@ import qualified Data.List as List
 
 --------------------------------------------------------------------------------
 
--- | A (non-empty) alternating list of a's and b's
+-- | A (non-empty) alternating list of @a@\'s and @b@\'s
 data Alternating a b = Alternating a [b :+ a] deriving (Show,Eq,Ord)
 
 instance Bifunctor Alternating where
@@ -44,7 +44,7 @@ withNeighbours (Alternating a0 xs) = let as = a0 : map (^.extra) xs
 
 
 -- | Generic merging scheme that merges two Alternatings and applies
--- the function 'f', with the current/new value at every event. So
+-- the function '@f@', with the current/new value at every event. So
 -- note that if the alternating consists of 'Alternating a0 [t1 :+
 -- a1]' then the function is applied to a1, not to a0 (i.e. every
 -- value ai is considered alive on the interval [ti,t(i+1))
@@ -72,7 +72,7 @@ mergeAlternating f (Alternating a00 as0)
 
 
 -- | Adds additional t-values in the alternating, (in sorted order). I.e. if we insert a
--- "breakpoint" at time t the current 'a' value is used at that time.
+-- "breakpoint" at time t the current '@a@' value is used at that time.
 --
 -- >>> insertBreakPoints [0,2,4,6,8,10] $ Alternating "a" [3 :+ "c", 5 :+ "e", 7 :+ "g"]
 -- Alternating "a" [0 :+ "a",2 :+ "a",3 :+ "c",4 :+ "c",5 :+ "e",6 :+ "e",7 :+ "g",8 :+ "g",10 :+ "g"]

--- a/hgeometry-combinatorial/src/Data/List/Set.hs
+++ b/hgeometry-combinatorial/src/Data/List/Set.hs
@@ -15,9 +15,9 @@ import qualified Data.List as List
 
 --------------------------------------------------------------------------------
 
--- | A Set of 'a's, implemented using a simple list. The only
+-- | A Set of @a@\'s, implemented using a simple list. The only
 -- advantage of this implementation over 'Data.Set' from containers is
--- that most operations require only 'Eq a' rather than 'Ord a'.
+-- that most operations require only @'Eq a'@ rather than @'Ord a'@.
 newtype Set a = Set { toList :: [a] }
               deriving (Show,Read,Functor,Foldable,Traversable)
 

--- a/hgeometry-combinatorial/src/Data/PlanarGraph/Core.hs
+++ b/hgeometry-combinatorial/src/Data/PlanarGraph/Core.hs
@@ -89,6 +89,7 @@ newtype VertexId s (w :: World) = VertexId { _unVertexId :: Int }
 -- | Shorthand for vertices in the primal.
 type VertexId' s = VertexId s Primal
 
+-- | Getter for a VertexId's unique number.
 unVertexId :: Getter (VertexId s w) Int
 unVertexId = to _unVertexId
 

--- a/hgeometry-combinatorial/src/Data/PlanarGraph/Core.hs
+++ b/hgeometry-combinatorial/src/Data/PlanarGraph/Core.hs
@@ -149,14 +149,17 @@ instance (Eq v, Eq e, Eq f) => Eq (PlanarGraph s w v e f) where
 embedding :: Getter (PlanarGraph s w v e f) (Permutation (Dart s))
 embedding = to _embedding
 
+-- | O\(1\) access, \( O(n) \) update.
 vertexData :: Lens (PlanarGraph s w v e f) (PlanarGraph s w v' e f)
                    (V.Vector v) (V.Vector v')
 vertexData = lens _vertexData (\g vD -> updateData (const vD) id id g)
 
+-- | O\(1\) access, \( O(n) \) update.
 rawDartData :: Lens (PlanarGraph s w v e f) (PlanarGraph s w v e' f)
                     (V.Vector e) (V.Vector e')
 rawDartData = lens _rawDartData (\g dD -> updateData id (const dD) id g)
 
+-- | O\(1\) access, \( O(n) \) update.
 faceData :: Lens (PlanarGraph s w v e f) (PlanarGraph s w v e f')
                  (V.Vector f) (V.Vector f')
 faceData = lens _faceData (\g fD -> updateData id id (const fD) g)
@@ -480,7 +483,7 @@ prevIncidentEdge d g = let perm  = g^.embedding
 --------------------------------------------------------------------------------
 -- * Access data
 
-
+-- | General interface to accessing vertex data, dart data, and face data.
 class HasDataOf g i where
   type DataOf g i
   -- | get the data associated with the value i.

--- a/hgeometry-combinatorial/src/Data/PlanarGraph/Dart.hs
+++ b/hgeometry-combinatorial/src/Data/PlanarGraph/Dart.hs
@@ -62,7 +62,16 @@ rev Positive = Negative
 data Dart s = Dart { _arc       :: !(Arc s)
                    , _direction :: !Direction
                    } deriving (Eq,Ord,Generic)
-makeLenses ''Dart
+
+-- | Arc lens.
+arc :: Lens' (Dart s) (Arc s)
+arc = lens _arc (\d a -> d{_arc = a})
+
+-- | Direction lens.
+direction :: Lens' (Dart s) Direction
+direction = lens _direction (\d dir -> d{_direction = dir})
+
+-- makeLenses ''Dart
 
 instance NFData (Dart s)
 

--- a/hgeometry-combinatorial/src/Data/Range.hs
+++ b/hgeometry-combinatorial/src/Data/Range.hs
@@ -108,7 +108,14 @@ data Range a = Range { _lower :: !(EndPoint a)
                      , _upper :: !(EndPoint a)
                      }
                deriving (Eq,Functor,Foldable,Traversable,Generic,NFData)
-makeLenses ''Range
+
+-- | Lens access for the lower part of a range.
+lower :: Lens' (Range a) (EndPoint a)
+lower = lens _lower (\r l -> r{_lower=l})
+
+-- | Lens access for the upper part of a range.
+upper :: Lens' (Range a) (EndPoint a)
+upper = lens _upper (\r u -> r{_upper=u})
 
 -- instance Show a => Show (Range a) where
 --   show (Range l u) = printf "Range (%s) (%s)" (show l) (show u)
@@ -219,6 +226,7 @@ instance Ord a => Range a `IsIntersectableWith` Range a where
 width   :: Num r => Range r -> r
 width i = i^.upper.unEndPoint - i^.lower.unEndPoint
 
+-- | Compute the halfway point between the start and end of a range.
 midPoint   :: Fractional r => Range r -> r
 midPoint r = let w = width r in r^.lower.unEndPoint + (w / 2)
 

--- a/hgeometry-combinatorial/src/Data/RealNumber/Rational.hs
+++ b/hgeometry-combinatorial/src/Data/RealNumber/Rational.hs
@@ -80,14 +80,21 @@ instance Random (RealNumber p) where
 
 
 
-
+-- | Fixed-precision representation of a 'RealNumber'. If there's insufficient
+--   precision to accurately represent the 'RealNumber' then the 'Lossy' constructor
+--   will be used.
 data AsFixed p = Exact !(Fixed p) | Lossy !(Fixed p) deriving (Show,Eq)
 
+-- | Cast 'RealNumber' to a fixed-precision number. Data is silently lost if there's
+--   insufficient precision.
 toFixed :: KnownNat p => RealNumber p -> Fixed (NatPrec p)
 toFixed = realToFrac
 
+-- | Cast a fixed-precision number to a 'RealNumber'.
 fromFixed :: KnownNat p => Fixed (NatPrec p) -> RealNumber p
 fromFixed = realToFrac
 
+-- | Cast 'RealNumber' to a fixed-precision number. Data-loss caused by insufficient
+--   precision will be marked by the 'Lossy' constructor.
 asFixed   :: KnownNat p => RealNumber p -> AsFixed (NatPrec p)
 asFixed r = let p = toFixed r in if r == fromFixed p then Exact p else Lossy p

--- a/hgeometry-combinatorial/src/Data/Set/Util.hs
+++ b/hgeometry-combinatorial/src/Data/Set/Util.hs
@@ -39,6 +39,13 @@ splitOn f x s = let (l,s') = Set.spanAntitone (g LT . f) s
                     g c y  = y `compare` x == c
                 in (l,m,r)
 
+-- | Given a monotonic function f that orders @a@, split the sequence @s@
+-- into three parts. I.e. the result (lt,eq,gt) is such that
+-- * all (\x -> f x == LT) . fmap f $ lt
+-- * all (\x -> f x == EQ) . fmap f $ eq
+-- * all (\x -> f x == GT) . fmap f $ gt
+--
+-- running time: \(O(\log n)\)
 splitBy       :: (a -> Ordering) -> Set a -> (Set a, Set a, Set a)
 splitBy f s = let (l,s') = Set.spanAntitone ((==) LT . f) s
                   (m,r)  = Set.spanAntitone ((==) EQ . f) s'

--- a/hgeometry-combinatorial/src/Data/Tree/Util.hs
+++ b/hgeometry-combinatorial/src/Data/Tree/Util.hs
@@ -140,8 +140,8 @@ findEvert' p = fmap unZipperLocal . List.find (p . focus) . allTrees . root
 --which one is returned.
 --
 -- running time: \(O(n(T_p+T_s)\), where \(n\) is the size of the tree, and
--- \(T_p\) and \(T_s\) are the times it takes to evaluate the 'isStartingNode'
--- and 'isEndingNode' predicates.
+-- \(T_p\) and \(T_s\) are the times it takes to evaluate the @isStartingNode@
+-- and @isEndingNode@ predicates.
 --
 --
 -- >>> findPath (== 1) (==4) myTree

--- a/hgeometry-combinatorial/src/Data/Util.hs
+++ b/hgeometry-combinatorial/src/Data/Util.hs
@@ -48,6 +48,7 @@ instance Field3 (STR a b c) (STR a b d) c d where
 -- | Strict Triple with all items the same
 type Three = V3
 
+-- | Pattern synonym for strict triples.
 pattern Three :: a -> a -> a -> Three a
 pattern Three a b c = V3 a b c
 {-# COMPLETE Three #-}
@@ -89,6 +90,7 @@ instance Bifunctor SP where
 -- | Strict pair with both items the same
 type Two = V2
 
+-- | Pattern synonym for strict pairs.
 pattern Two :: a -> a -> Two a
 pattern Two a b = V2 a b
 {-# COMPLETE Two #-}

--- a/hgeometry-combinatorial/src/Data/Vector/Circular/Util.hs
+++ b/hgeometry-combinatorial/src/Data/Vector/Circular/Util.hs
@@ -1,4 +1,11 @@
 {-# OPTIONS_GHC -fno-warn-orphans #-}
+--------------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Vector.Circular.Util
+-- Copyright   :  (C) Frank Staals, David Himmelstrup
+-- License     :  see the LICENSE file
+-- Maintainer  :  David Himmelstrup
+--------------------------------------------------------------------------------
 module Data.Vector.Circular.Util where
 
 import           Algorithms.StringSearch.KMP (isSubStringOf)

--- a/hgeometry-combinatorial/src/Data/Yaml/Util.hs
+++ b/hgeometry-combinatorial/src/Data/Yaml/Util.hs
@@ -66,6 +66,7 @@ data Versioned a = Versioned { version :: Version
                              , content :: a
                              } deriving (Show,Read,Generic,Eq,Functor,Foldable,Traversable)
 
+-- | Unpack versioned data type.
 unversioned :: Versioned a -> a
 unversioned = content
 

--- a/hgeometry/src/Algorithms/Geometry/DelaunayTriangulation/DivideAndConquer.hs
+++ b/hgeometry/src/Algorithms/Geometry/DelaunayTriangulation/DivideAndConquer.hs
@@ -161,7 +161,7 @@ moveUp ut l r
                      moveUp ut l' r'
 
 
--- | ''rotates'' around r and removes all neighbours of r that violate the
+-- | \'rotates\' around r and removes all neighbours of r that violate the
 -- delaunay condition. Returns the first vertex (as a Neighbour of r) that
 -- should remain in the Delaunay Triangulation, as well as a boolean A that
 -- helps deciding if we merge up by rotating left or rotating right (See
@@ -280,7 +280,7 @@ size'              :: BinLeafTree Size a -> Size
 size' (Leaf _)     = 1
 size' (Node _ s _) = s
 
--- | an 'unsafe' version of rotateTo that assumes the element to rotate to
+-- | an \'unsafe\' version of rotateTo that assumes the element to rotate to
 -- occurs in the list.
 rotateTo   :: Eq a => a -> CL.CList a -> CL.CList a
 rotateTo x = fromJust . CL.rotateTo x

--- a/hgeometry/src/Algorithms/Geometry/EuclideanMST.hs
+++ b/hgeometry/src/Algorithms/Geometry/EuclideanMST.hs
@@ -9,7 +9,7 @@
 -- spanning tree of a set of \(n\) points in \(\mathbb{R}^2\).
 --
 --------------------------------------------------------------------------------
-module Algorithms.Geometry.EuclideanMST where
+module Algorithms.Geometry.EuclideanMST ( euclideanMST ) where
 
 import           Algorithms.Geometry.DelaunayTriangulation.DivideAndConquer
 import           Algorithms.Geometry.DelaunayTriangulation.Types

--- a/hgeometry/src/Data/Geometry/Interval.hs
+++ b/hgeometry/src/Data/Geometry/Interval.hs
@@ -23,7 +23,7 @@ module Data.Geometry.Interval(
                              ) where
 
 import           Control.DeepSeq
-import           Control.Lens             (Lens', lens, (%~), (&), (^.))
+import           Control.Lens             (Lens', (%~), (&), (^.), Iso', iso)
 import           Data.Bifunctor
 import           Data.Bitraversable
 import           Data.Ext
@@ -44,11 +44,16 @@ import           Test.QuickCheck
 -- We can think of an interval being defined as:
 --
 -- >>> data Interval a r = Interval (EndPoint (r :+ a)) (EndPoint (r :+ a))
-newtype Interval a r = GInterval { toRange :: Range (r :+ a) }
+newtype Interval a r = GInterval (Range (r :+ a))
                      deriving (Eq,Generic,Arbitrary)
 
-_Range :: Lens' (Interval a r) (Range (r :+ a))
-_Range = lens toRange (const fromRange)
+-- | Cast an interval to a range.
+toRange :: Interval a r -> Range (r :+ a)
+toRange (GInterval r) = r
+
+-- | Intervals and ranges are isomorphic.
+_Range :: Iso' (Interval a r) (Range (r :+ a))
+_Range = iso toRange fromRange
 {-# INLINE _Range #-}
 
 -- | Constrct an interval from a Range

--- a/hgeometry/src/Data/Geometry/Polygon/Inflate.hs
+++ b/hgeometry/src/Data/Geometry/Polygon/Inflate.hs
@@ -1,3 +1,10 @@
+--------------------------------------------------------------------------------
+-- |
+-- Module      :  Data.Geometry.Polygon.Inflate
+-- Copyright   :  (C) David Himmelstrup
+-- License     :  see the LICENSE file
+-- Maintainer  :  David Himmelstrup
+--------------------------------------------------------------------------------
 module Data.Geometry.Polygon.Inflate
   ( Arc(..)
   , inflate

--- a/hgeometry/src/Data/Geometry/SubLine.hs
+++ b/hgeometry/src/Data/Geometry/SubLine.hs
@@ -84,6 +84,7 @@ fixEndPoints sl = sl&subRange %~ f
 dropExtra :: SubLine d p s r -> SubLine d () s r
 dropExtra = over subRange (first (const ()))
 
+-- | Prism for downcasting an unbounded subline to a subline.
 _unBounded :: Prism' (SubLine d p (UnBounded r) r) (SubLine d p r r)
 _unBounded = prism' toUnbounded fromUnbounded
 

--- a/hgeometry/src/Data/Geometry/Vector/VectorFamily.hs
+++ b/hgeometry/src/Data/Geometry/Vector/VectorFamily.hs
@@ -214,7 +214,7 @@ element' :: forall d r. Arity d => Int -> Traversal' (Vector d r) r
 element' i = unV.e (C :: C d) i
   where
     e  :: Arity d => proxy d -> Int -> Traversal' (VectorFamily (Peano d) r) r
-    e _ = Fam.element'
+    e _ = ix
 {-# INLINE element' #-}
 
 --------------------------------------------------------------------------------

--- a/hgeometry/src/Data/Geometry/Vector/VectorFamilyPeano.hs
+++ b/hgeometry/src/Data/Geometry/Vector/VectorFamilyPeano.hs
@@ -7,7 +7,12 @@
 -- License     :  see the LICENSE file
 -- Maintainer  :  Frank Staals
 --------------------------------------------------------------------------------
-module Data.Geometry.Vector.VectorFamilyPeano where
+module Data.Geometry.Vector.VectorFamilyPeano
+  ( ImplicitArity
+  , VectorFamily(VectorFamily)
+  , VectorFamilyF
+  , FromPeano
+  ) where
 
 import           Control.Applicative (liftA2)
 import           Control.DeepSeq
@@ -304,14 +309,14 @@ instance (ToJSON r, ImplicitArity d) => ToJSON (VectorFamily d r) where
 vectorFromList :: ImplicitArity d => [r] -> Maybe (VectorFamily d r)
 vectorFromList = V.fromListM
 
-vectorFromListUnsafe :: ImplicitArity d => [r] -> VectorFamily d r
-vectorFromListUnsafe = V.fromList
+-- vectorFromListUnsafe :: ImplicitArity d => [r] -> VectorFamily d r
+-- vectorFromListUnsafe = V.fromList
 
--- | Get the head and tail of a vector
-destruct   :: (ImplicitArity d, ImplicitArity (S d))
-           => VectorFamily (S d) r -> (r, VectorFamily d r)
-destruct v = (head $ F.toList v, vectorFromListUnsafe . tail $ F.toList v)
-  -- FIXME: this implementaion of tail is not particularly nice
+-- -- | Get the head and tail of a vector
+-- destruct   :: (ImplicitArity d, ImplicitArity (S d))
+--            => VectorFamily (S d) r -> (r, VectorFamily d r)
+-- destruct v = (head $ F.toList v, vectorFromListUnsafe . tail $ F.toList v)
+--   -- FIXME: this implementaion of tail is not particularly nice
 
 -- snoc     :: (ImplicitArity d, ImplicitArity (S d))
 --          => VectorFamily d r -> r -> VectorFamily (S d) r


### PR DESCRIPTION
`hgeometry-combinatorial` is completely documented with the following exceptions:
 - `Control.CanAquire`: I don't understand what does module does. Looks to be related to `SoS`.
 - `Data.Permutation`: This module is only used by `PlanarGraph`.
 - `Data.PlanarGraph.IO`: All of this code can be replaced by the new planar graph implementation.