### PR TITLE
fix rename maximumBy to maximumVertexBy in showcase

### DIFF
--- a/hgeometry-showcase/lib/Common.hs
+++ b/hgeometry-showcase/lib/Common.hs
@@ -33,10 +33,10 @@ import Data.Geometry.Vector
 pCenter :: (Fractional r, Ord r) => SimplePolygon p r -> Point 2 r
 pCenter p = Point2 (minX + (maxX-minX)/2) (minY + (maxY-minY)/2)
   where
-    Point2 maxX _ :+ _ = maximumBy (comparing (view (core.xCoord))) p
-    Point2 minX _ :+ _ = minimumBy (comparing (view (core.xCoord))) p
-    Point2 _ maxY :+ _ = maximumBy (comparing (view (core.yCoord))) p
-    Point2 _ minY :+ _ = minimumBy (comparing (view (core.yCoord))) p
+    Point2 maxX _ :+ _ = maximumVertexBy (comparing (view (core.xCoord))) p
+    Point2 minX _ :+ _ = minimumVertexBy (comparing (view (core.xCoord))) p
+    Point2 _ maxY :+ _ = maximumVertexBy (comparing (view (core.yCoord))) p
+    Point2 _ minY :+ _ = minimumVertexBy (comparing (view (core.yCoord))) p
 
 pAtCenter :: (Fractional r, Ord r) => SimplePolygon p r -> SimplePolygon p r
 pAtCenter p = translateBy (neg $ toVec $ pCenter p) p

--- a/hgeometry-showcase/src/RandomMonotone.hs
+++ b/hgeometry-showcase/src/RandomMonotone.hs
@@ -72,8 +72,8 @@ randomMonotoneSingle p' dir = scene $ do
       | iPt <- intersectionsAt p' dir atP ]
   where
     pts = map _core $ toPoints p
-    minP = P.minimumBy (cmpExtreme dir) p'
-    maxP = P.maximumBy (cmpExtreme dir) p'
+    minP = P.minimumVertexBy (cmpExtreme dir) p'
+    maxP = P.maximumVertexBy (cmpExtreme dir) p'
     Just p = P.findRotateTo (==minP) p'
 
 intersectionsAt :: SimplePolygon () R -> Vector 2 R -> Point 2 R -> [Point 2 R]


### PR DESCRIPTION
I think the variable name was changed in 29e3746 and this allows hgeometry-showcase to compile.