### PR TITLE
Add missing Functor, Foldable and Traversable instances

### DIFF
--- a/hgeometry-combinatorial/src/Data/Ext.hs
+++ b/hgeometry-combinatorial/src/Data/Ext.hs
@@ -37,6 +37,14 @@ import Test.QuickCheck
 data core :+ extra = core :+ extra deriving (Show,Read,Eq,Ord,Bounded,Generic,NFData)
 infixr 1 :+
 
+instance Functor ((:+) c) where
+  fmap f (c :+ e) = c :+ f e
+
+instance Foldable ((:+) c) where
+  foldMap f (_ :+ e) = f e
+
+instance Traversable ((:+) c) where
+  traverse f (c :+ e) = (:+) c <$> f e
 
 instance Bifunctor (:+) where
   bimap f g (c :+ e) = f c :+ g e

--- a/hgeometry-combinatorial/src/Data/List/Alternating.hs
+++ b/hgeometry-combinatorial/src/Data/List/Alternating.hs
@@ -16,14 +16,24 @@ module Data.List.Alternating(
 import Prelude hiding (reverse)
 import Control.Lens
 import Data.Bifoldable
+import Data.Bifunctor
 import Data.Bitraversable
 import Data.Ext
+import Data.Traversable
 import qualified Data.List as List
 
 --------------------------------------------------------------------------------
 
 -- | A (non-empty) alternating list of @a@\'s and @b@\'s
 data Alternating a b = Alternating a [b :+ a] deriving (Show,Eq,Ord)
+
+  
+instance Functor (Alternating a) where
+  fmap = fmapDefault
+instance Foldable (Alternating a) where
+  foldMap = foldMapDefault
+instance Traversable (Alternating a) where
+  traverse = bitraverse pure
 
 instance Bifunctor Alternating where
   bimap = bimapDefault

--- a/hgeometry-combinatorial/src/Data/PlanarGraph/AdjRep.hs
+++ b/hgeometry-combinatorial/src/Data/PlanarGraph/AdjRep.hs
@@ -25,9 +25,15 @@ data Gr v f = Gr { adjacencies :: [v]
                  , faces       :: [f]
                  } deriving (Generic, Show, Eq)
 
+instance Functor (Gr v) where
+  fmap f (Gr vs fs) = Gr vs (map f fs)
+instance Foldable (Gr v) where
+  foldMap f (Gr _ fs) = foldMap f fs
+instance Traversable (Gr v) where
+  traverse f (Gr vs fs) = Gr vs <$> traverse f fs
+
 instance Bifunctor Gr where
   bimap f g (Gr vs fs) = Gr (map f vs) (map g fs)
-
 instance Bifoldable Gr where
   bifoldMap f g (Gr vs fs) = foldMap f vs <> foldMap g fs
 instance Bitraversable Gr where
@@ -54,12 +60,19 @@ data Vtx v e = Vtx { id    :: {-# UNPACK #-} !Int
                    , vData :: !v
                    } deriving (Generic, Show, Eq)
 
+instance Functor (Vtx v) where
+  fmap f (Vtx i as x) = Vtx i (map (second f) as) x
+instance Foldable (Vtx v) where
+  foldMap f (Vtx _ ads _) = foldMap (f . snd) ads
+instance Traversable (Vtx v) where
+  traverse f (Vtx i adjs x) = Vtx i <$> traverse (traverse f) adjs <*> pure x
+
 instance Bifunctor Vtx where
   bimap f g (Vtx i as x) = Vtx i (map (second g) as) (f x)
 instance Bifoldable Vtx where
   bifoldMap f g (Vtx _ ads x) = foldMap (g . snd) ads <> f x
 instance Bitraversable Vtx where
-  bitraverse f g (Vtx i adjs x) = Vtx i <$> traverse (bitraverse pure g) adjs <*> f x
+  bitraverse f g (Vtx i adjs x) = Vtx i <$> traverse (traverse g) adjs <*> f x
 
 instance (ToJSON v, ToJSON e)     => ToJSON   (Vtx v e) where
   toEncoding = genericToEncoding defaultOptions

--- a/hgeometry-combinatorial/src/Data/Tree/Util.hs
+++ b/hgeometry-combinatorial/src/Data/Tree/Util.hs
@@ -1,6 +1,7 @@
 -- | Tree-related utilities.
 module Data.Tree.Util where
 
+import           Data.Traversable
 import           Data.Bifoldable
 import           Data.Bifunctor
 import           Data.Bitraversable
@@ -27,6 +28,13 @@ import           Data.Tree
 
 -- | Nodes in a tree are typically either an internal node or a leaf node
 data TreeNode v a = InternalNode v | LeafNode a deriving (Show,Eq)
+
+instance Functor (TreeNode a) where
+  fmap = fmapDefault
+instance Foldable (TreeNode a) where
+  foldMap = foldMapDefault
+instance Traversable (TreeNode a) where
+  traverse = bitraverse pure
 
 instance Bifunctor TreeNode where
   bimap = bimapDefault

--- a/hgeometry/src/Geometry/Box/Internal.hs
+++ b/hgeometry/src/Geometry/Box/Internal.hs
@@ -25,6 +25,7 @@ import qualified Data.Foldable as F
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Range as R
 import qualified Data.Semigroup.Foldable as F
+import           Data.Traversable
 import qualified Data.Vector.Fixed as FV
 import           Data.Vinyl.CoRec (asA)
 import           GHC.Generics (Generic)
@@ -155,6 +156,13 @@ instance (Ord r, Arity d) => Box d p r `IsIntersectableWith` Box d q r where
     where
       f = maybe (coRec NoIntersection) (coRec . fromExtent)
       r `intersect'` s = asA @(R.Range r) $ r `intersect` s
+
+instance Arity d => Functor (Box d p) where
+  fmap = fmapDefault
+instance Arity d => Foldable (Box d p) where
+  foldMap = foldMapDefault
+instance Arity d => Traversable (Box d p) where
+  traverse = bitraverse pure
 
 instance Arity d => Bifunctor (Box d) where
   bimap = bimapDefault

--- a/hgeometry/src/Geometry/PolyLine.hs
+++ b/hgeometry/src/Geometry/PolyLine.hs
@@ -15,6 +15,7 @@ import           Data.Bifunctor
 import           Data.Bitraversable
 import           Data.Ext
 import qualified Data.Foldable as F
+import           Data.Traversable
 import           Geometry.Box
 import           Geometry.LineSegment
 import           Geometry.Point
@@ -67,6 +68,11 @@ instance (Fractional r, Arity d, Arity (d + 1)) => IsTransformable (PolyLine d p
 
 instance PointFunctor (PolyLine d p) where
   pmap f = over points (fmap (first f))
+
+instance Arity d => Foldable (PolyLine d p) where
+  foldMap = foldMapDefault
+instance Arity d => Traversable (PolyLine d p) where
+  traverse = bitraverse pure
 
 instance Arity d => Bifunctor (PolyLine d) where
   bimap = bimapDefault

--- a/hgeometry/src/Geometry/Polygon/Core.hs
+++ b/hgeometry/src/Geometry/Polygon/Core.hs
@@ -170,6 +170,12 @@ _MultiPolygon = prism' (uncurry MultiPolygon) (\(MultiPolygon vs hs) -> Just (vs
 instance Functor (Polygon t p) where
   fmap = bimap id
 
+instance Foldable (Polygon t p) where
+  foldMap = bifoldMap (const mempty) 
+  
+instance Traversable (Polygon t p) where
+  traverse = bitraverse pure
+
 instance Bifunctor (Polygon t) where
   bimap = bimapDefault
 

--- a/hgeometry/src/Geometry/QuadTree/Tree.hs
+++ b/hgeometry/src/Geometry/QuadTree/Tree.hs
@@ -17,6 +17,7 @@ import           Data.Bitraversable
 import           Data.Ext
 import qualified Data.Foldable as F
 import           Data.Functor.Apply
+import           Data.Traversable
 import           Geometry.Point
 import           Geometry.QuadTree.Cell
 import           Geometry.QuadTree.Quadrants
@@ -38,6 +39,15 @@ data Tree v p = Leaf !p
               | Node !v (Quadrants (Tree v p)) -- quadrants are stored lazily on purpose
               deriving (Show,Eq)
 makePrisms ''Tree
+  
+instance Functor (Tree a) where
+  fmap = fmapDefault
+
+instance Foldable (Tree a) where
+  foldMap = foldMapDefault
+
+instance Traversable (Tree a) where
+  traverse = bitraverse pure
 
 instance Bifunctor Tree where
   bimap = bimapDefault

--- a/hgeometry/src/Geometry/Triangle.hs
+++ b/hgeometry/src/Geometry/Triangle.hs
@@ -10,6 +10,7 @@ import           Data.Bifunctor (Bifunctor (first))
 import           Data.Bitraversable
 import           Data.Either (partitionEithers)
 import           Data.Ext
+import           Data.Traversable
 import           Geometry.Ball (Disk, disk)
 import           Geometry.Boundary (PointLocationResult (..))
 import           Geometry.Box (IsBoxable (..))
@@ -46,6 +47,9 @@ deriving instance (Arity d, Eq r, Eq p)         => Eq     (Triangle d p r)
 
 instance (Arity d, NFData r, NFData p) => NFData (Triangle d p r)
 
+instance Arity d => Functor (Triangle d p) where fmap = fmapDefault
+instance Arity d => Foldable (Triangle d p) where foldMap = foldMapDefault
+instance Arity d => Traversable (Triangle d p) where traverse = bitraverse pure
 instance Arity d => Bifunctor  (Triangle d) where bimap = bimapDefault
 instance Arity d => Bifoldable (Triangle d) where bifoldMap = bifoldMapDefault
 


### PR DESCRIPTION
Adresses haskell/core-libraries-committee#91 and haskell/core-libraries-committee#93

Note that I have _not_ added `Foldable1` and `Traversable1` instances for `Tree` in `Data.Geometry.QuadTree.Tree`.