### PR TITLE
Using Cyclic NonEmpty rather than NonEmpty in Polygons

### DIFF
--- a/hgeometry-examples/lowerEnv/Main.hs
+++ b/hgeometry-examples/lowerEnv/Main.hs
@@ -15,6 +15,7 @@ import qualified Data.Map.NonEmpty as NEMap
 import           Data.Maybe (fromMaybe)
 import           Data.Ord (comparing)
 import           HGeometry.Box
+import           HGeometry.Cyclic
 import           HGeometry.Ext
 import           HGeometry.HyperPlane.NonVertical
 import           HGeometry.Number.Real.Rational
@@ -88,9 +89,10 @@ myPoints = NonEmpty.zipWith (flip (:+)) myColors $
 
 
 -- | Renders the a plane
-renderPlaneIn             :: (Plane_ plane r, Point_ corner 2 r, Num r, Ord r
-                             , Show corner, Show r)
-                          => Rectangle corner -> plane -> ConvexPolygonF NonEmpty (corner :+ r)
+renderPlaneIn         :: (Plane_ plane r, Point_ corner 2 r, Num r, Ord r
+                         , Show corner, Show r)
+                      => Rectangle corner -> plane
+                      -> ConvexPolygonF (Cyclic NonEmpty) (corner :+ r)
 renderPlaneIn rect' h = uncheckedFromCCWPoints
                       . NonEmpty.reverse . toNonEmpty -- the corners are listed in CW order
                       . fmap eval
@@ -100,7 +102,7 @@ renderPlaneIn rect' h = uncheckedFromCCWPoints
 
 toPolygons :: (Plane_ plane r, Ord r, Fractional r, Point_ vertex 2 r)
            => MinimizationDiagram r vertex plane
-           -> NonEmpty (plane, ConvexPolygonF NonEmpty (Point 2 r :+ r))
+           -> NonEmpty (plane, ConvexPolygonF (Cyclic NonEmpty) (Point 2 r :+ r))
 toPolygons = fmap render . NEMap.toAscList . asMap
   where
     render (h,reg) = (h, case toConvexPolygonIn myRect reg of
@@ -214,7 +216,7 @@ main = do
 
 -- | make sure that all vertices lie on the plane
 verifyOnPlane        :: (Plane_ plane r, Ord r, Fractional r)
-                     => (plane, ConvexPolygonF NonEmpty (Point 2 r :+ r)) -> Bool
+                     => (plane, ConvexPolygonF (Cyclic NonEmpty) (Point 2 r :+ r)) -> Bool
 verifyOnPlane (h,pg) = allOf vertices onPlane pg
   where
     onPlane (Point2 x y :+ z) = onHyperPlane (Point3 x y z) h

--- a/hgeometry/polygon/src/HGeometry/Polygon/Convex/Unbounded.hs
+++ b/hgeometry/polygon/src/HGeometry/Polygon/Convex/Unbounded.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE UndecidableInstances  #-}
 --------------------------------------------------------------------------------
 -- |
 -- Module      :  HGeometry.Polygon.Convex.Unbounded
@@ -25,6 +26,7 @@ import           Data.List.NonEmpty (NonEmpty(..))
 import qualified Data.List.NonEmpty as NonEmpty
 import           Data.Maybe (fromMaybe)
 import           Data.Ord (comparing)
+import           HGeometry.Cyclic
 import           HGeometry.HalfLine
 import           HGeometry.HalfSpace
 import           HGeometry.HyperPlane.Class
@@ -258,7 +260,7 @@ instance ( Point_ vertex 2 r, Num r, Ord r
 -- -- intersect the convex region with the left halfplane of l.
 -- intersectVerticalLeft :: r -> UnboundedConvexRegionF r nonEmpty vertex
 --                            -> Either (UnboundedConvexRegionF r nonEmpty vertex)
---                                      (ConvexPolygonF NonEmpty vertex)
+--                                      (ConvexPolygonF (Cyclic NonEmpty) vertex)
 -- intersectVerticalLeft x chain@(Chain v pts w) =
 --   case (verticalLine x `intersect`) <$> boundingRays chain of
 --     Vector2 Nothing Nothing
@@ -267,7 +269,7 @@ instance ( Point_ vertex 2 r, Num r, Ord r
 --------------------------------------------------------------------------------
 
 type instance Intersection (Triangle corner) (UnboundedConvexRegionF r nonEmpty vertex)
-  = Intersection (Triangle corner) (ConvexPolygonF nonEmpty vertex)
+  = Intersection (Triangle corner) (ConvexPolygonF (Cyclic nonEmpty) vertex)
 
 instance (Point_ vertex 2 r, Point_ corner 2 r, Ord r, Fractional r
          ) => Triangle corner `HasIntersectionWith` (UnboundedConvexRegionF r NonEmpty vertex)
@@ -284,7 +286,7 @@ instance ( Point_ vertex 2 r, Point_ corner 2 r, Ord r, Fractional r
 -- this is to avoid having to introduce yet another level of 'OriginalOrExtra''s
 toBoundedFrom :: (Foldable nonEmpty, Point_ point 2 r, Point_ vertex 2 r, Ord r, Fractional r)
               => nonEmpty point -> UnboundedConvexRegionF r NonEmpty vertex
-              -> ConvexPolygonF NonEmpty vertex
+              -> ConvexPolygonF (Cyclic NonEmpty) vertex
 toBoundedFrom tri reg@(Unbounded v pts w) = go $ case extremalVertices reg of
                                                    Left p    -> Vector2 p p
                                                    Right vec -> vec

--- a/hgeometry/src/HGeometry/Plane/LowerEnvelope/Connected/Region.hs
+++ b/hgeometry/src/HGeometry/Plane/LowerEnvelope/Connected/Region.hs
@@ -65,13 +65,13 @@ instance Num r => Point_ (MDVertex r plane) 2 r where
 
 -- | A Convex bounded region, which may be clipped using vertices of type 'corner'.
 type ClippedBoundedRegion r vertex corner =
-  ConvexPolygonF NonEmpty (OriginalOrExtra vertex corner)
+  ConvexPolygonF (Cyclic NonEmpty) (OriginalOrExtra vertex corner)
 
 --------------------------------------------------------------------------------
 
 -- | A region in the minimization diagram. The boundary is given in CCW order; i.e. the
 -- region is to the left of the boundary.
-data Region r vertex = BoundedRegion   (ConvexPolygonF NonEmpty vertex)
+data Region r vertex = BoundedRegion   (ConvexPolygonF (Cyclic NonEmpty) vertex)
                      | UnboundedRegion (UnboundedConvexRegionF r NonEmpty vertex)
                      deriving stock (Functor,Foldable,Traversable)
 

--- a/hgeometry/src/HGeometry/Plane/LowerEnvelope/Connected/Type.hs
+++ b/hgeometry/src/HGeometry/Plane/LowerEnvelope/Connected/Type.hs
@@ -51,6 +51,7 @@ import           Data.Map.NonEmpty (NEMap)
 import qualified Data.Map.NonEmpty as NEMap
 import           Data.Monoid (First(..))
 import           HGeometry.Box
+import           HGeometry.Cyclic
 -- import           HGeometry.Cyclic
 import           HGeometry.Direction
 import           HGeometry.HalfLine
@@ -116,8 +117,8 @@ toConvexPolygonIn      :: ( Rectangle_ rectangle corner, Point_ corner 2 r
                           , Point_ point 2 r, Ord r, Fractional r
                           )
                        => rectangle -> Region r point
-                       -> Either (ConvexPolygonF NonEmpty point)
-                                 (ConvexPolygonF NonEmpty (OriginalOrExtra point (Point 2 r)))
+                       -> Either (ConvexPolygonF (Cyclic NonEmpty) point)
+                                 (ConvexPolygonF (Cyclic NonEmpty) (OriginalOrExtra point (Point 2 r)))
 toConvexPolygonIn rect = \case
     BoundedRegion convex                -> Left convex
     UnboundedRegion (Unbounded u pts v) ->

--- a/hgeometry/test-with-ipe/test/Plane/LowerEnvelopeSpec.hs
+++ b/hgeometry/test-with-ipe/test/Plane/LowerEnvelopeSpec.hs
@@ -16,6 +16,7 @@ import qualified Data.Set as Set
 import qualified Data.Text as Text
 import           Golden
 import           HGeometry.Box
+import           HGeometry.Cyclic
 import           HGeometry.Ext
 import           HGeometry.Number.Real.Rational
 import           HGeometry.Plane.LowerEnvelope
@@ -56,7 +57,7 @@ instance ( Point_ point 2 r, Fractional r, Ord r
          => HasDefaultIpeOut (Region r point) where
   type DefaultIpeOut (Region r point) = Path
   defIO region = defIO $ case toConvexPolygonIn rect' region of
-                   Left pg  -> (pg&vertices %~ view asPoint :: ConvexPolygonF NonEmpty (Point 2 r))
+                   Left pg  -> (pg&vertices %~ view asPoint :: ConvexPolygonF (Cyclic NonEmpty) (Point 2 r))
                    Right pg -> pg&vertices %~ view asPoint
     where
       rect' = grow 1000 $ boundingBox region

--- a/hgeometry/test-with-ipe/test/Plane/NaiveLowerEnvSpec.hs
+++ b/hgeometry/test-with-ipe/test/Plane/NaiveLowerEnvSpec.hs
@@ -4,6 +4,8 @@ module Plane.NaiveLowerEnvSpec
   ( spec
   ) where
 
+import           HGeometry.Cyclic
+-- import HGeometry.Polygon.Simple
 import           Control.Lens hiding (IsEmpty, IsNonEmpty)
 import           Control.Subcategory.Functor
 import           Data.Bifunctor
@@ -124,7 +126,7 @@ instance ( Point_ vertex 2 r, Fractional r, Ord r
   type DefaultIpeOut (ClippedMDCell' r vertex) = Path
   defIO (ClippedMDCell cell) = case cell of
     ActualPolygon cell' -> defIO $ (cell'&vertices %~ (^.asPoint)
-                                     :: ConvexPolygonF NonEmpty (Point 2 r)
+                                     :: ConvexPolygonF (Cyclic NonEmpty) (Point 2 r)
                                    )
     _                   -> error "defIO for clippedMDCell rendering segment or point not defined"
 
@@ -169,10 +171,8 @@ myTest = describe "intersection tests" $ do
     it "triangle unbounded conex poly intersection "  $
       (tri `intersects` unboundedPoly) `shouldBe` True
 
--- convexPoly :: ConvexPolygonF NonEmpty (Point 2 R) -- FIXME!!!
--- apparently something goes wrong using NonEmpty rather than NonEmptyVector
-
-convexPoly :: ConvexPolygon (Point 2 R)
+-- convexPoly :: ConvexPolygon (Point 2 R)
+convexPoly :: ConvexPolygonF (Cyclic NonEmpty) (Point 2 R)
 convexPoly = fromMaybe (error "absurd") $ fromPoints $ NonEmpty.fromList
   [ Point2 281.99      1636.18
   , Point2 (-662.455) 1636.18
@@ -180,7 +180,6 @@ convexPoly = fromMaybe (error "absurd") $ fromPoints $ NonEmpty.fromList
   , Point2 (-305.312) (-363.818)
   , Point2 337.545    636.182
   ]
-
 
 unboundedPoly :: UnboundedConvexRegion (Point 2 R)
 unboundedPoly = Unbounded (Vector2 1 1.55555)

--- a/hgeometry/test-with-ipe/test/TriangleUnboundedConvexSpec.hs
+++ b/hgeometry/test-with-ipe/test/TriangleUnboundedConvexSpec.hs
@@ -66,7 +66,7 @@ ipeSpec' outFP (chain,tri) = traceShow chain $
                                    ! attr SFill red
     , iO' chain
     , iO' tri
---     , iO $ defIO ((toBoundedFrom tri chain)&vertices %~ (^.asPoint)  :: ConvexPolygonF NonEmpty (Point 2 R)
+--     , iO $ defIO ((toBoundedFrom tri chain)&vertices %~ (^.asPoint)  :: ConvexPolygonF (Cyclic NonEmpty) (Point 2 R)
 --                 ) ! attr SFill blue
     ]
 


### PR DESCRIPTION
This fixed some bug/crash in the testsuite. Hoping it may avoid issues in the lower envelope stuff as well (where I had a similar crash before).